### PR TITLE
Allow the Y axes to be removed

### DIFF
--- a/src/components/ChartContainer/index.js
+++ b/src/components/ChartContainer/index.js
@@ -33,7 +33,7 @@ class ChartContainer extends Component {
   getChartWidth = () => {
     const {
       width,
-      yAxis: { width: yAxisWidth },
+      yAxis: { width: yAxisWidth, display: yAxisDisplayMode },
       hiddenSeries,
       margin,
       series,
@@ -42,12 +42,9 @@ class ChartContainer extends Component {
     const nHiddenSeries = Object.keys(hiddenSeries).filter(
       s => hiddenSeries[s] === true
     ).length;
-    return (
-      width -
-      yAxisWidth * (nSeries - nHiddenSeries) -
-      margin.left -
-      margin.right
-    );
+    const visibleAxesCount =
+      yAxisDisplayMode === 'NONE' ? 0 : nSeries - nHiddenSeries;
+    return width - yAxisWidth * visibleAxesCount - margin.left - margin.right;
   };
 
   subDomainChanged = domain => {
@@ -95,6 +92,9 @@ class ChartContainer extends Component {
       .domain(subDomain)
       .range([0, chartWidth]);
     const children = React.Children.map(this.props.children, child => {
+      if (!child) {
+        return;
+      }
       heightOffset += ((child.props.margin || {}).top || 0) * chartHeight;
       const c = React.cloneElement(child, {
         ...this.props,

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -23,7 +23,16 @@ export default class DataProvider extends Component {
   }
 
   shouldComponentUpdate(
-    { config, loader, width, height, colors, hiddenSeries, annotations },
+    {
+      config,
+      loader,
+      width,
+      height,
+      colors,
+      hiddenSeries,
+      annotations,
+      children,
+    },
     { subDomain: nextSubdomain, series }
   ) {
     if (!isEqual(annotations, this.props.annotations)) {
@@ -39,6 +48,9 @@ export default class DataProvider extends Component {
       return true;
     }
     if (!isEqual(hiddenSeries, this.props.hiddenSeries)) {
+      return true;
+    }
+    if (!isEqual(children, this.props.children)) {
       return true;
     }
     const { subDomain } = this.state;
@@ -59,6 +71,9 @@ export default class DataProvider extends Component {
       return true;
     }
     if (!isEqual(config.yAxis, this.props.config.yAxis)) {
+      return true;
+    }
+    if (config.showContext !== this.props.config.showContext) {
       return true;
     }
     const allKeys = uniq([...keys, ...currentKeys]);
@@ -165,6 +180,7 @@ export default class DataProvider extends Component {
     }
     const children = React.Children.map(this.props.children, (child, i) => {
       const props = {
+        config,
         colors,
         hiddenSeries,
         annotations,

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -55,9 +55,15 @@ export default class LineChart extends Component {
       margin,
       hiddenSeries,
       annotations,
+      config,
     } = this.props;
     const effectiveHeight = height * heightPct;
     const { linex, liney } = this.state;
+    let yAxisDisplayMode = 'ALL';
+    if (config.yAxis && config.yAxis.display) {
+      yAxisDisplayMode = config.yAxis.display;
+    }
+    const showAxes = yAxisDisplayMode === 'ALL';
     return (
       <g className="line-chart" transform={`translate(0, ${offsetY})`}>
         {linex &&
@@ -132,19 +138,24 @@ export default class LineChart extends Component {
                     .range([effectiveHeight, 0])
                     .nice()
                 );
-            return [
-              <Axis
-                key={`axis--${key}`}
-                id={key}
-                scale={yScale}
-                zoomable={!staticScale}
-                mode="y"
-                offsetx={width + idx * yAxis.width}
-                width={yAxis.width}
-                offsety={effectiveHeight}
-                strokeColor={colors[key]}
-                updateYScale={this.props.updateYScale}
-              />,
+            var items = [];
+            if (showAxes) {
+              items.push(
+                <Axis
+                  key={`axis--${key}`}
+                  id={key}
+                  scale={yScale}
+                  zoomable={!staticScale}
+                  mode="y"
+                  offsetx={width + idx * yAxis.width}
+                  width={yAxis.width}
+                  offsety={effectiveHeight}
+                  strokeColor={colors[key]}
+                  updateYScale={this.props.updateYScale}
+                />
+              );
+            }
+            items.push(
               <Line
                 key={`line--${key}`}
                 data={serie.data}
@@ -155,8 +166,9 @@ export default class LineChart extends Component {
                 color={colors[key]}
                 step={serie.step}
                 drawPoints={serie.drawPoints}
-              />,
-            ];
+              />
+            );
+            return items;
           })}
         <rect
           ref={ref => {

--- a/stories/index.js
+++ b/stories/index.js
@@ -409,4 +409,42 @@ storiesOf('DataProvider', module)
     withInfo()(() => {
       return <StaticAxis />;
     })
+  )
+  .add(
+    'without y-axes',
+    withInfo()(() => {
+      const loader = () => {
+        const series = {
+          1: { data: randomData(), id: 1 },
+          2: { data: randomData(), id: 2 },
+          3: { data: randomData(), id: 3 },
+        };
+        return () => series;
+      };
+      const config = {
+        ...baseConfig,
+        yAxis: {
+          ...baseConfig.yAxis,
+          display: 'NONE',
+        },
+      };
+      return (
+        <DataProvider
+          config={config}
+          margin={{ top: 50, bottom: 10, left: 20, right: 10 }}
+          height={500}
+          width={800}
+          loader={loader()}
+          colors={{
+            1: 'red',
+            2: 'green',
+            3: 'blue',
+          }}
+        >
+          <ChartContainer>
+            <LineChart heightPct={1} crosshairs />
+          </ChartContainer>
+        </DataProvider>
+      );
+    })
   );


### PR DESCRIPTION
By using the following configuration options on the <DataProvider>, the
y axes will not be rendered (the series still will be).

config: {
  yAxis {
    display: 'NONE',
  }
}

Supported values are 'NONE' and 'ALL'. Any other values will behave as
if 'ALL' was specified.