### PR TITLE
Allow disabling of chart zooming

### DIFF
--- a/src/components/Axis.js
+++ b/src/components/Axis.js
@@ -25,11 +25,19 @@ function multiFormat(date) {
         : d3.timeDay(date) < date
           ? formatHour
           : d3.timeMonth(date) < date
-            ? d3.timeWeek(date) < date ? formatDay : formatWeek
-            : d3.timeYear(date) < date ? formatMonth : formatYear)(date);
+            ? d3.timeWeek(date) < date
+              ? formatDay
+              : formatWeek
+            : d3.timeYear(date) < date
+              ? formatMonth
+              : formatYear)(date);
 }
 
 export default class Axis extends Component {
+  static defaultProps = {
+    zoomable: true,
+  };
+
   componentWillMount() {
     this.zoom = d3.zoom().on('zoom', this.didZoom);
   }
@@ -54,6 +62,9 @@ export default class Axis extends Component {
 
   renderZoomRect() {
     if (this.props.mode === 'x') {
+      return null;
+    }
+    if (!this.props.zoomable) {
       return null;
     }
     const { offsetx, offsety, width } = this.props;

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -10,6 +10,10 @@ export default class LineChart extends Component {
     liney: null,
   };
 
+  isZoomable() {
+    return 'zoomable' in this.props.config ? this.props.config.zoomable : true;
+  }
+
   componentDidMount() {
     this.selection = d3.select(this.zoomNode);
     this.selection.call(this.props.zoom.on('zoom', this.zoomed));
@@ -24,6 +28,9 @@ export default class LineChart extends Component {
   }
 
   zoomed = () => {
+    if (!this.isZoomable()) {
+      return null;
+    }
     const t = d3.event.transform;
     const scale = this.props.xScale;
     const newScale = t.rescaleX(scale);
@@ -145,7 +152,7 @@ export default class LineChart extends Component {
                   key={`axis--${key}`}
                   id={key}
                   scale={yScale}
-                  zoomable={!staticScale}
+                  zoomable={this.isZoomable() && !staticScale}
                   mode="y"
                   offsetx={width + idx * yAxis.width}
                   width={yAxis.width}

--- a/stories/index.js
+++ b/stories/index.js
@@ -449,6 +449,41 @@ storiesOf('DataProvider', module)
     })
   )
   .add(
+    'without zooming',
+    withInfo()(() => {
+      const loader = () => {
+        const series = {
+          1: { data: randomData(), id: 1 },
+          2: { data: randomData(), id: 2 },
+          3: { data: randomData(), id: 3 },
+        };
+        return () => series;
+      };
+      const config = {
+        ...baseConfig,
+        zoomable: false,
+      };
+      return (
+        <DataProvider
+          config={config}
+          margin={{ top: 50, bottom: 10, left: 20, right: 10 }}
+          height={500}
+          width={800}
+          loader={loader()}
+          colors={{
+            1: 'red',
+            2: 'green',
+            3: 'blue',
+          }}
+        >
+          <ChartContainer>
+            <LineChart heightPct={1} crosshairs />
+          </ChartContainer>
+        </DataProvider>
+      );
+    })
+  )
+  .add(
     'Toggle time line chart',
     withInfo()(() => {
       const loader = () => {


### PR DESCRIPTION
Add a new flag (zoomable) to the config object which allows for the
chart to be rendered without zooming. Disabling zooming for the chart
also disables zooming of the axes.