### PR TITLE
If onMouseOut was passed to LineChart, call it

### DIFF
--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -279,6 +279,7 @@ export default class LineChart extends Component {
             if (crosshairs) {
               this.setState({ linex: null, liney: null });
             }
+            this.props.onMouseOut && this.props.onMouseOut(e);
           }}
         />
       </g>


### PR DESCRIPTION
If the caller has asked for onMouseOut to be called (by weay of
specifiying a callback), then call it when onMouseOut occurs.