### PR TITLE
Use key, not index, for strokeWidth

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -226,7 +226,7 @@ DataProvider.propTypes = {
   updateInterval: PropTypes.number,
   hiddenSeries: PropTypes.objectOf(PropTypes.bool),
   annotations: PropTypes.arrayOf(PropTypes.object),
-  strokeWidths: PropTypes.arrayOf(PropTypes.number),
+  strokeWidths: PropTypes.objectOf(PropTypes.number),
 };
 
 DataProvider.defaultProps = {
@@ -238,5 +238,5 @@ DataProvider.defaultProps = {
   },
   hiddenSeries: {},
   annotations: [],
-  strokeWidths: [],
+  strokeWidths: {},
 };

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -7,11 +7,11 @@ import PropTypes from 'prop-types';
 
 export default class LineChart extends Component {
   static propTypes = {
-    strokeWidths: PropTypes.arrayOf(PropTypes.number),
+    strokeWidths: PropTypes.objectOf(PropTypes.number),
   };
 
   static defaultProps = {
-    strokeWidths: [],
+    strokeWidths: {},
   };
 
   state = {
@@ -195,7 +195,7 @@ export default class LineChart extends Component {
                 color={colors[key]}
                 step={serie.step}
                 drawPoints={serie.drawPoints}
-                strokeWidth={strokeWidths[idx]}
+                strokeWidth={strokeWidths[key]}
               />
             );
             return items;

--- a/stories/index.js
+++ b/stories/index.js
@@ -638,12 +638,12 @@ storiesOf('DataProvider', module)
                   step={1}
                   onChange={value => {
                     const copy = [...strokeWidths];
-                    copy[index] = value;
+                    copy[key] = value;
                     this.setState({
                       strokeWidths: copy,
                     });
                   }}
-                  value={strokeWidths[index]}
+                  value={strokeWidths[key]}
                 />
               ))}
             </div>


### PR DESCRIPTION
Use an object for the strokeWidth parameter, rather than an array.