### PR TITLE
Create an encapsulated Series object

### DIFF
--- a/src/components/AxisCollection/YAxis.js
+++ b/src/components/AxisCollection/YAxis.js
@@ -1,0 +1,116 @@
+import React, { Component } from 'react';
+import * as d3 from 'd3';
+import PropTypes from 'prop-types';
+
+export default class YAxis extends Component {
+  static defaultProps = {
+    zoomable: true,
+    series: PropTypes.object,
+    height: PropTypes.number.isRequired,
+  };
+
+  static defaultScaler = { rescaleY: d => d };
+
+  componentWillMount() {
+    this.zoom = d3.zoom().on('zoom', this.didZoom);
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevProps.zoomable != this.props.zoomable) {
+      this.syncZoomingState();
+    }
+  }
+
+  componentDidMount() {
+    this.selection = d3.select(this.zoomNode);
+    this.syncZoomingState();
+  }
+
+  syncZoomingState = () => {
+    if (this.props.zoomable) {
+      this.selection.call(this.zoom);
+    } else {
+      this.selection.on('.zoom', null);
+    }
+  };
+
+  didZoom = () => {
+    const t = d3.event.transform;
+    this.props.updateYScale(t, this.props.series.id);
+  };
+
+  renderZoomRect() {
+    const { height, series } = this.props;
+    return (
+      <rect
+        width={series.width}
+        height={height}
+        fill="none"
+        pointerEvents="all"
+        ref={ref => {
+          this.zoomNode = ref;
+        }}
+      />
+    );
+  }
+
+  renderAxis() {
+    const { series } = this.props;
+    const { height, strokeColor = 'black' } = this.props;
+    const scale = series.scale([height, 0]);
+    const axis = d3.axisRight(scale);
+    const tickFontSize = 14;
+    const strokeWidth = 2;
+    const halfStrokeWidth = strokeWidth / 2;
+    const tickSizeOuter = axis.tickSizeOuter();
+    const tickSizeInner = axis.tickSizeInner();
+    const tickPadding = axis.tickPadding();
+    const values = scale.ticks();
+    const k = 1;
+    const tickFormat = scale.tickFormat();
+    const range = scale.range().map(r => r + halfStrokeWidth);
+    const pathString = `M${k * tickSizeOuter},${range[0]}H${halfStrokeWidth}V${
+      range[1]
+    }H${k * tickSizeOuter}`;
+    return (
+      <g
+        className="axis"
+        fill="none"
+        fontSize={tickFontSize}
+        textAnchor="start"
+        strokeWidth={strokeWidth}
+      >
+        <path stroke={strokeColor} d={pathString} />
+        {values.map(v => {
+          const lineProps = { stroke: strokeColor };
+          lineProps[`x2`] = k * tickSizeInner;
+          lineProps[`y1`] = halfStrokeWidth;
+          lineProps[`y2`] = halfStrokeWidth;
+
+          const textProps = {
+            fill: strokeColor,
+            dy: '0.32em',
+          };
+          textProps['x'] = k * Math.max(tickSizeInner, 0) + tickPadding;
+          textProps['y'] = halfStrokeWidth;
+          return (
+            <g key={+v} opacity={1} transform={`translate(0, ${scale(v)})`}>
+              <line {...lineProps} />
+              <text {...textProps}>{tickFormat(v)}</text>
+            </g>
+          );
+        })}
+      </g>
+    );
+  }
+
+  render() {
+    const { offsetx } = this.props;
+    return (
+      <g className={`axis-y`} transform={`translate(${offsetx}, 0)`}>
+        {this.renderAxis()}
+        {this.renderZoomRect()}
+      </g>
+    );
+  }
+}

--- a/src/components/AxisCollection/index.js
+++ b/src/components/AxisCollection/index.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import * as d3 from 'd3';
+import YAxis from './YAxis';
+
+class AxisCollection extends React.Component {
+  static propTypes = {
+    series: PropTypes.object,
+    zoomable: PropTypes.bool,
+    updateYScale: PropTypes.func,
+    offsetx: PropTypes.number,
+    offsety: PropTypes.number,
+    rescaleY: PropTypes.func,
+  };
+
+  static defaultProps: {
+    series: [],
+    zoomable: true,
+    updateYScale: () => {},
+    offsetx: 0,
+    offsety: 0,
+  };
+
+  renderAxes() {
+    const { series, zoomable, height, updateYScale } = this.props;
+    let axisOffsetX = 0;
+    return Object.keys(series)
+      .filter(key => !series[key].hidden)
+      .map((key, idx) => {
+        const serie = series[key];
+        if (idx > 0) {
+          axisOffsetX += serie.width;
+        }
+        return (
+          <YAxis
+            key={`axis--${key}`}
+            zoomable={zoomable && !serie.staticDomain}
+            series={serie}
+            offsetx={axisOffsetX}
+            height={height}
+            strokeColor={serie.color}
+            updateYScale={updateYScale}
+          />
+        );
+      });
+  }
+
+  render() {
+    const { offsetx = 0 } = this.props;
+    return <g transform={`translate(${offsetx}, 0)`}>{this.renderAxes()}</g>;
+  }
+}
+
+export default AxisCollection;

--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -61,23 +61,13 @@ export default class ContextChart extends Component {
     }
   };
 
-  calculateDomainFromData = (data, yAccessor) => {
-    const extent = d3.extent(data, yAccessor);
-    const diff = extent[1] - extent[0];
-    return [extent[0] - diff * 0.025, extent[1] + diff * 0.025];
-  };
-
   render() {
     const {
-      yAxis,
-      xAxis,
       contextSeries: series,
       height,
       heightPct,
       offsetY,
       xScale,
-      colors,
-      hiddenSeries,
       annotations,
     } = this.props;
     const effectiveHeight = height * heightPct;
@@ -103,27 +93,17 @@ export default class ContextChart extends Component {
         ))}
         {Object.keys(series).map(key => {
           const serie = series[key];
-          const yDomain = yAxis.calculateDomain
-            ? yAxis.calculateDomain(serie.data)
-            : this.calculateDomainFromData(
-                serie.data,
-                serie.yAccessor || yAxis.accessor
-              );
-          const yScale = d3
-            .scaleLinear()
-            .domain(yDomain)
-            .range([effectiveHeight, 0])
-            .nice();
+          const yScale = serie.scale([effectiveHeight, 0]);
           return (
             <Line
               key={`line--${key}`}
               data={serie.data}
-              hidden={hiddenSeries[key]}
+              hidden={serie.hidden}
               xScale={xScale}
               yScale={yScale}
-              xAccessor={serie.xAccessor || xAxis.accessor}
-              yAccessor={serie.yAccessor || yAxis.accessor}
-              color={colors[key]}
+              xAccessor={serie.xAccessor}
+              yAccessor={serie.yAccessor}
+              color={serie.color}
               step={serie.step}
             />
           );

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import * as d3 from 'd3';
 import Line from '../Line';
 import Axis from '../Axis';
+import AxisCollection from '../AxisCollection';
 import Annotation from '../Annotation';
 import PropTypes from 'prop-types';
 
@@ -138,67 +139,31 @@ export default class LineChart extends Component {
             />
           ))}
         </g>
+        <AxisCollection
+          heightPct={1}
+          series={series}
+          height={effectiveHeight}
+          offsetx={width}
+          updateYScale={this.props.updateYScale}
+        />
         {Object.keys(series)
-          .filter(key => !hiddenSeries[key])
+          .filter(key => !series[key].hidden)
           .map((key, idx) => {
             const serie = series[key];
-            const yAccessor = serie.yAccessor || yAxis.accessor;
-            const yDomain = yAxis.calculateDomain
-              ? yAxis.calculateDomain(serie.data)
-              : this.calculateDomainFromData(serie.data, yAccessor);
-            let scaler = rescaleY[key];
-            if (!scaler) {
-              scaler = { rescaleY: d => d };
-            }
-            const staticDomain = (yAxis.staticDomain || {})[key];
-            let staticScale;
-            if (staticDomain) {
-              staticScale = d3
-                .scaleLinear()
-                .domain(staticDomain)
-                .range([effectiveHeight, 0]);
-            }
-            const yScale = staticScale
-              ? staticScale
-              : scaler.rescaleY(
-                  d3
-                    .scaleLinear()
-                    .domain(yDomain)
-                    .range([effectiveHeight, 0])
-                    .nice()
-                );
-            var items = [];
-            if (showAxes) {
-              items.push(
-                <Axis
-                  key={`axis--${key}`}
-                  id={key}
-                  scale={yScale}
-                  zoomable={this.isZoomable() && !staticScale}
-                  mode="y"
-                  offsetx={width + idx * yAxis.width}
-                  width={yAxis.width}
-                  offsety={effectiveHeight}
-                  strokeColor={colors[key]}
-                  updateYScale={this.props.updateYScale}
-                />
-              );
-            }
-            items.push(
+            return (
               <Line
                 key={`line--${key}`}
                 data={serie.data}
                 xScale={xScale}
-                xAccessor={serie.xAccessor || xAxis.accessor}
-                yAccessor={serie.yAccessor || yAxis.accessor}
-                yScale={yScale}
-                color={colors[key]}
+                xAccessor={serie.xAccessor}
+                yAccessor={serie.yAccessor}
+                yScale={serie.scale([effectiveHeight, 0])}
+                color={serie.color}
                 step={serie.step}
                 drawPoints={serie.drawPoints}
-                strokeWidth={strokeWidths[key]}
+                strokeWidth={serie.strokeWidth}
               />
             );
-            return items;
           })}
         <rect
           ref={ref => {

--- a/src/data/Series.js
+++ b/src/data/Series.js
@@ -1,0 +1,43 @@
+import * as d3 from 'd3';
+
+/**
+ * Represents a data series.
+ */
+export default class Series {
+  static defaultScaler = { rescaleY: d => d };
+
+  constructor(obj) {
+    Object.keys(obj).forEach(key => {
+      this[key] = obj[key];
+    });
+  }
+
+  calculateDomainFromData = () => {
+    const extent = d3.extent(this.data, this.yAccessor);
+    const diff = extent[1] - extent[0];
+    if (Math.abs(diff) < 1e-3) {
+      return [1 / 2 * extent[0], 3 / 2 * extent[0]];
+    }
+    return [extent[0] - diff * 0.025, extent[1] + diff * 0.025];
+  };
+
+  scale = range => {
+    if (this.staticDomain) {
+      return d3
+        .scaleLinear()
+        .domain(this.staticDomain)
+        .range(range);
+    }
+    const scaler = this.scaler || Series.defaultScaler;
+    const yDomain = this.calculateDomain
+      ? this.calculateDomain(data)
+      : this.calculateDomainFromData();
+    return scaler.rescaleY(
+      d3
+        .scaleLinear()
+        .domain(yDomain)
+        .range(range)
+        .nice()
+    );
+  };
+}

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -1,0 +1,1 @@
+export { default } from './Series';

--- a/stories/index.js
+++ b/stories/index.js
@@ -115,6 +115,42 @@ storiesOf('DataProvider', module)
     })
   )
   .add(
+    'with metadata contained in series object',
+    withInfo()(() => {
+      const loader = () => {
+        const series = {
+          1: {
+            data: randomData().map(r => ({
+              timestamp: r.timestamp,
+              y: r.value,
+            })),
+            id: 1,
+            yAccessor: d => d.y,
+            step: true,
+            color: 'red',
+          },
+          2: { data: randomData(), id: 2, color: 'green', strokeWidth: 3 },
+          3: { data: randomData(), id: 3, color: 'blue' },
+          4: { data: randomData(), id: 4, color: 'orange', hidden: true },
+        };
+        return () => series;
+      };
+      return (
+        <DataProvider
+          config={baseConfig}
+          margin={{ top: 50, bottom: 10, left: 10, right: 10 }}
+          height={500}
+          width={800}
+          loader={loader()}
+        >
+          <ChartContainer>
+            <LineChart heightPct={1} crosshairs />
+          </ChartContainer>
+        </DataProvider>
+      );
+    })
+  )
+  .add(
     'with static data and timeline',
     withInfo()(() => {
       const loader = () => {


### PR DESCRIPTION
As data enters the DataProvider, convert it into an instance of a Series
object. This will contain all of the metadata as well as the functions
that callers will use down the line, like scale calculations.

This also allows the callers to have the metadata live directly with the
series object passed in from the loader, instead of as a series of
disconnected metadata objects (eg: hiddenSeries, colors, strokeWidths).
Backwards compatibility is maintained by mixing the metadata arrays in
the DataProvider, with the series object's metadata taking precedence.

Finally, create an AxisCollection object and extract a dedicaetd YAxis
object. These maintain single-responsibility behavior, where they are
only responsible for rendering their level of data. This gives us much
more manageable code in LineChart and Axis. It also allows for an
<AxisCollection> to be added as a sibling of <LineChart>, but this has
not yet been implemented because it causes issues with calculating the
chart width once the axes become dynamically shown and hidden.