### PR TITLE
Do not scale the ContextChart

### DIFF
--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -93,7 +93,7 @@ export default class ContextChart extends Component {
         ))}
         {Object.keys(series).map(key => {
           const serie = series[key];
-          const yScale = serie.scale([effectiveHeight, 0]);
+          const yScale = serie.staticScale([effectiveHeight, 0]);
           return (
             <Line
               key={`line--${key}`}

--- a/src/data/Series.js
+++ b/src/data/Series.js
@@ -23,10 +23,7 @@ export default class Series {
 
   scale = range => {
     if (this.staticDomain) {
-      return d3
-        .scaleLinear()
-        .domain(this.staticDomain)
-        .range(range);
+      return this.staticScale(range);
     }
     const scaler = this.scaler || Series.defaultScaler;
     const yDomain = this.calculateDomain
@@ -39,5 +36,16 @@ export default class Series {
         .range(range)
         .nice()
     );
+  };
+
+  staticScale = range => {
+    const domain = this.staticDomain
+      ? this.staticDomain
+      : this.calculateDomainFromData();
+    return d3
+      .scaleLinear()
+      .domain(domain)
+      .range(range)
+      .nice();
   };
 }


### PR DESCRIPTION
When drawing the lines on the ContextChart, do not use the scale()
method on the Series object -- this will lead to dynamic scaling in the
ContextChart, which is not what we want. Instead, extract out a
staticScale() method to ignore the current scaling.