### PR TITLE
Use a unique clipPath for each LineChart

### DIFF
--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -15,6 +15,7 @@ const Line = ({
   hidden,
   drawPoints,
   strokeWidth,
+  clipPath,
 }) => {
   let line;
   let area;
@@ -65,7 +66,7 @@ const Line = ({
       ));
   }
   return (
-    <g clipPath="url(#linechart-clip-path)">
+    <g clipPath={`url(#${clipPath})`}>
       {area && (
         <path
           d={area(data)}
@@ -107,6 +108,7 @@ Line.propTypes = {
   hidden: PropTypes.bool,
   drawPoints: PropTypes.bool,
   strokeWidth: PropTypes.number,
+  clipPath: PropTypes.string.isRequired,
 };
 
 Line.defaultProps = {

--- a/src/components/LineCollection/index.js
+++ b/src/components/LineCollection/index.js
@@ -8,13 +8,25 @@ import Line from '../Line';
 const LineCollection = props => {
   const { series, width, height, domain } = props;
   const xScale = createXScale(domain, width);
+  const clipPath = `clip-path-${series
+    .filter(s => !s.hidden)
+    .map(s => s.id)
+    .join('-')}`;
   const lines = series.filter(s => !s.hidden).map(s => {
     const yScale = createYScale(s.yDomain, height);
-    return <Line key={s.id} {...s} xScale={xScale} yScale={yScale} />;
+    return (
+      <Line
+        key={s.id}
+        {...s}
+        xScale={xScale}
+        yScale={yScale}
+        clipPath={clipPath}
+      />
+    );
   });
   return (
     <g width={width} height={height}>
-      <clipPath id="linechart-clip-path">
+      <clipPath id={clipPath}>
         <rect width={width} height={height} fill="none" />
       </clipPath>
       {lines}

--- a/stories/index.js
+++ b/stories/index.js
@@ -109,6 +109,42 @@ storiesOf('LineChart', module)
     ))
   )
   .add(
+    'Multiple',
+    withInfo()(() => (
+      <React.Fragment>
+        <DataProvider
+          defaultLoader={staticLoader}
+          baseDomain={staticBaseDomain}
+          series={[
+            { id: 1, color: 'steelblue' },
+            { id: 2, color: 'maroon' },
+            { id: 3, color: 'orange' },
+          ]}
+        >
+          <LineChart height={CHART_HEIGHT} />
+        </DataProvider>
+        <DataProvider
+          defaultLoader={staticLoader}
+          baseDomain={staticBaseDomain}
+          series={[
+            { id: 1, color: 'steelblue' },
+            { id: 2, color: 'maroon' },
+            { id: 3, color: 'orange', hidden: true },
+          ]}
+        >
+          <LineChart height={CHART_HEIGHT} />
+        </DataProvider>
+        <DataProvider
+          defaultLoader={staticLoader}
+          baseDomain={staticBaseDomain}
+          series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+        >
+          <LineChart height={CHART_HEIGHT} />
+        </DataProvider>
+      </React.Fragment>
+    ))
+  )
+  .add(
     'Sized',
     withInfo()(() => (
       <div>


### PR DESCRIPTION
For each instance of LineChart, name the clipPath a unique identifier so
that multiple LineChart instances on a page do not collide