### PR TITLE
Add support for min/max area

### DIFF
--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -6,6 +6,8 @@ const Line = ({
   data,
   xAccessor,
   yAccessor,
+  y0Accessor,
+  y1Accessor,
   xScale,
   yScale,
   color,
@@ -26,6 +28,14 @@ const Line = ({
       .line()
       .x(d => xScale(xAccessor(d)))
       .y(d => yScale(yAccessor(d)));
+  }
+  let area = null;
+  if (y0Accessor && y1Accessor) {
+    area = d3
+      .area()
+      .x(d => xScale(xAccessor(d)))
+      .y0(d => yScale(y0Accessor(d)))
+      .y1(d => yScale(y1Accessor(d)));
   }
   let circles = null;
   if (drawPoints) {
@@ -48,6 +58,18 @@ const Line = ({
   }
   return (
     <g clipPath="url(#linechart-clip-path)">
+      {area && (
+        <path
+          d={area(data)}
+          style={{
+            stroke: 'none',
+            strokeWidth: `${strokeWidth}px`,
+            fill: `${color}`,
+            opacity: 0.25,
+            display: hidden ? 'none' : 'inherit',
+          }}
+        />
+      )}
       <path
         d={line(data)}
         style={{
@@ -68,6 +90,8 @@ Line.propTypes = {
   data: PropTypes.array.isRequired,
   xAccessor: PropTypes.func.isRequired,
   yAccessor: PropTypes.func.isRequired,
+  y0Accessor: PropTypes.func.isRequired,
+  y1Accessor: PropTypes.func.isRequired,
   color: PropTypes.string.isRequired,
   step: PropTypes.bool,
   hidden: PropTypes.bool,

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -56,8 +56,18 @@ export default class LineChart extends Component {
     return this.props.subDomainChanged(dd);
   };
 
-  calculateDomainFromData = (data, yAccessor) => {
-    const extent = d3.extent(data, yAccessor);
+  calculateDomainFromData = (
+    data,
+    yAccessor,
+    y0Accessor = null,
+    y1Accessor = null
+  ) => {
+    let extent;
+    if (y0Accessor && y1Accessor) {
+      extent = [d3.min(data, y0Accessor), d3.max(data, y1Accessor)];
+    } else {
+      extent = d3.extent(data, yAccessor);
+    }
     const diff = extent[1] - extent[0];
     if (Math.abs(diff) < 1e-3) {
       return [1 / 2 * extent[0], 3 / 2 * extent[0]];
@@ -143,9 +153,16 @@ export default class LineChart extends Component {
           .map((key, idx) => {
             const serie = series[key];
             const yAccessor = serie.yAccessor || yAxis.accessor;
+            const y0Accessor = serie.y0Accessor || yAxis.y0Accessor;
+            const y1Accessor = serie.y1Accessor || yAxis.y1Accessor;
             const yDomain = yAxis.calculateDomain
               ? yAxis.calculateDomain(serie.data)
-              : this.calculateDomainFromData(serie.data, yAccessor);
+              : this.calculateDomainFromData(
+                  serie.data,
+                  yAccessor,
+                  y0Accessor,
+                  y1Accessor
+                );
             let scaler = rescaleY[key];
             if (!scaler) {
               scaler = { rescaleY: d => d };
@@ -190,9 +207,9 @@ export default class LineChart extends Component {
                 data={serie.data}
                 xScale={xScale}
                 xAccessor={serie.xAccessor || xAxis.accessor}
-                yAccessor={serie.yAccessor || yAxis.accessor}
-                y0Accessor={serie.y0Accessor || yAxis.y0Accessor}
-                y1Accessor={serie.y1Accessor || yAxis.y1Accessor}
+                yAccessor={yAccessor}
+                y0Accessor={y0Accessor}
+                y1Accessor={y1Accessor}
                 yScale={yScale}
                 color={colors[key]}
                 step={serie.step}

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -191,6 +191,8 @@ export default class LineChart extends Component {
                 xScale={xScale}
                 xAccessor={serie.xAccessor || xAxis.accessor}
                 yAccessor={serie.yAccessor || yAxis.accessor}
+                y0Accessor={serie.y0Accessor || yAxis.y0Accessor}
+                y1Accessor={serie.y1Accessor || yAxis.y1Accessor}
                 yScale={yScale}
                 color={colors[key]}
                 step={serie.step}

--- a/stories/index.js
+++ b/stories/index.js
@@ -31,7 +31,7 @@ const baseConfig = {
   },
   xAxis: {
     accessor: d => d.timestamp,
-    calculateDomain: data => d3.extent(d => d.timestamp),
+    calculateDomain: data => d3.extent(data, d => d.timestamp),
   },
   baseDomain: d3.extent(randomData(), d => d.timestamp),
 };

--- a/stories/index.js
+++ b/stories/index.js
@@ -686,6 +686,41 @@ storiesOf('DataProvider', module)
       </DataProvider>
     );
   })
+  .add('min/max', () => {
+    const min = d => d.value * ((75 + d.timestamp % 10) / 100);
+    const max = d => d.value * ((110 + d.timestamp % 10) / 100);
+    const myloader = () => {
+      const series = {
+        1: {
+          data: randomData().map(r => ({ timestamp: r.timestamp, value: 15 })),
+          step: true,
+          y0Accessor: min,
+          y1Accessor: max,
+        },
+        2: {
+          data: randomData(),
+          y0Accessor: min,
+          y1Accessor: max,
+        },
+      };
+      return () => series;
+    };
+    const loader = myloader();
+    return (
+      <DataProvider
+        config={{ ...baseConfig }}
+        margin={{ top: 50, bottom: 10, left: 20, right: 10 }}
+        height={500}
+        width={800}
+        colors={{ 1: 'steelblue', 2: 'red' }}
+        loader={loader}
+      >
+        <ChartContainer>
+          <LineChart heightPct={1} crosshairs />
+        </ChartContainer>
+      </DataProvider>
+    );
+  })
   .add('Onclick', () => {
     const _loader = () => {
       const series = {


### PR DESCRIPTION
If y0Accessor and y1Accessor are specified with a series, draw an area
surrounding the line. This allows for uncertainty to be drawn if
desired.