### PR TITLE
Add AxisDisplayMode functionality

### DIFF
--- a/src/components/Annotation/index.js
+++ b/src/components/Annotation/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { annotationPropType } from '../../utils/proptypes';
+import { annotationShape } from '../../utils/proptypes';
 
 const Annotation = ({ data, xScale, height, color, fillOpacity, id }) => (
   <rect
@@ -12,7 +12,7 @@ const Annotation = ({ data, xScale, height, color, fillOpacity, id }) => (
   />
 );
 
-Annotation.propTypes = annotationPropType;
+Annotation.propTypes = annotationShape;
 
 Annotation.defaultProps = {
   color: '#e8336d',

--- a/src/components/AxisCollection/CollapsedAxis.js
+++ b/src/components/AxisCollection/CollapsedAxis.js
@@ -1,0 +1,138 @@
+import React, { Component } from 'react';
+import * as d3 from 'd3';
+import PropTypes from 'prop-types';
+import isEqual from 'lodash.isequal';
+import { createYScale } from '../../utils/scale-helpers';
+import { singleSeriePropType } from '../../utils/proptypes';
+
+export default class CollapsedAxis extends Component {
+  static propTypes = {
+    // TODO: Zooming is currently not supported.
+    // It might be nice to support zooming all of the axes when you zoom on
+    // the collapsed one. Experiment with this and either add it or remove
+    // all of this unused code.
+    zoomable: PropTypes.bool,
+    series: PropTypes.arrayOf(singleSeriePropType),
+    height: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+    updateYTransformation: PropTypes.func,
+    yTransformation: PropTypes.shape({
+      y: PropTypes.number.isRequired,
+      k: PropTypes.number.isRequired,
+      rescaleY: PropTypes.func.isRequired,
+    }),
+    color: PropTypes.string,
+  };
+
+  static defaultProps = {
+    series: [],
+    zoomable: false,
+    updateYTransformation: () => {},
+    yTransformation: null,
+    color: '#666',
+  };
+
+  componentWillMount() {
+    this.zoom = d3.zoom().on('zoom', this.didZoom);
+  }
+
+  componentDidMount() {
+    this.selection = d3.select(this.zoomNode);
+    this.syncZoomingState();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.zoomable !== this.props.zoomable) {
+      this.syncZoomingState();
+    }
+    if (this.props.yTransformation) {
+      if (!isEqual(prevProps.series.yDomain, this.props.series.yDomain)) {
+        this.selection.property('__zoom', this.props.yTransformation);
+      }
+    }
+  }
+
+  syncZoomingState = () => {
+    if (this.props.zoomable) {
+      this.selection.call(this.zoom);
+    } else {
+      this.selection.on('.zoom', null);
+    }
+  };
+
+  didZoom = () => {
+    const t = d3.event.transform;
+    this.props.updateYTransformation(
+      this.props.series.id,
+      t,
+      this.props.height
+    );
+  };
+
+  renderZoomRect() {
+    const { height, width } = this.props;
+    return (
+      <rect
+        width={width}
+        height={height}
+        fill="none"
+        pointerEvents="all"
+        ref={ref => {
+          this.zoomNode = ref;
+        }}
+      />
+    );
+  }
+
+  renderAxis() {
+    const { color, height } = this.props;
+    const scale = createYScale([0, 100], height);
+    const axis = d3.axisRight(scale);
+    const tickFontSize = 14;
+    const strokeWidth = 2;
+    const halfStrokeWidth = strokeWidth / 2;
+    const tickSizeOuter = axis.tickSizeOuter();
+    const tickSizeInner = axis.tickSizeInner();
+    const values = scale.ticks();
+    const k = 2.5;
+    const range = scale.range().map(r => r + halfStrokeWidth);
+    const pathString = [
+      `M${k * tickSizeOuter},${range[0]}`,
+      `H${halfStrokeWidth}`,
+      `V${range[1]}`,
+      `H${k * tickSizeOuter}`,
+    ].join('');
+    return (
+      <g
+        className="axis"
+        fill="none"
+        fontSize={tickFontSize}
+        textAnchor="start"
+        strokeWidth={strokeWidth}
+      >
+        <path stroke={color} d={pathString} />
+        {values.map(v => {
+          const lineProps = { stroke: color };
+          lineProps.x2 = k * tickSizeInner;
+          lineProps.y1 = halfStrokeWidth;
+          lineProps.y2 = halfStrokeWidth;
+          return (
+            <g key={+v} opacity={1} transform={`translate(0, ${scale(v)})`}>
+              <line {...lineProps} />
+            </g>
+          );
+        })}
+      </g>
+    );
+  }
+
+  render() {
+    const { zoomable } = this.props;
+    return (
+      <g className="axis-y">
+        {this.renderAxis()}
+        {zoomable && this.renderZoomRect()}
+      </g>
+    );
+  }
+}

--- a/src/components/AxisCollection/index.js
+++ b/src/components/AxisCollection/index.js
@@ -1,72 +1,130 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import CollapsedAxis from './CollapsedAxis';
 import YAxis from './YAxis';
 import ScalerContext from '../../context/Scaler';
-import { seriesPropType } from '../../utils/proptypes';
+import { seriesPropType, axisDisplayModeType } from '../../utils/proptypes';
+import AxisDisplayMode from '../LineChart/AxisDisplayMode';
+
+const propTypes = {
+  height: PropTypes.number.isRequired,
+  width: PropTypes.number.isRequired,
+  series: seriesPropType,
+  zoomable: PropTypes.bool,
+  updateYTransformation: PropTypes.func,
+  yAxisWidth: PropTypes.number,
+  yTransformations: PropTypes.objectOf(
+    PropTypes.shape({
+      k: PropTypes.number.isRequired,
+      y: PropTypes.number.isRequired,
+      rescaleY: PropTypes.func.isRequired,
+    })
+  ).isRequired,
+  axisDisplayMode: axisDisplayModeType,
+  onMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+};
+
+const defaultProps = {
+  series: [],
+  zoomable: true,
+  updateYTransformation: () => {},
+  yAxisWidth: 50,
+  axisDisplayMode: AxisDisplayMode.ALL,
+  onMouseEnter: null,
+  onMouseLeave: null,
+};
 
 class AxisCollection extends React.Component {
-  static propTypes = {
-    width: PropTypes.number.isRequired,
-    height: PropTypes.number.isRequired,
-    series: seriesPropType,
-    zoomable: PropTypes.bool,
-    updateYTransformation: PropTypes.func,
-    yAxisWidth: PropTypes.number,
-    yTransformations: PropTypes.objectOf(
-      PropTypes.shape({
-        k: PropTypes.number.isRequired,
-        y: PropTypes.number.isRequired,
-        rescaleY: PropTypes.func.isRequired,
-      })
-    ).isRequired,
+  showCollapsedAxis = () => {
+    const { series, axisDisplayMode } = this.props;
+    return series.filter(
+      s =>
+        !s.hidden &&
+        (s.yAxisDisplayMode || axisDisplayMode) === AxisDisplayMode.COLLAPSED
+    ).length;
   };
 
-  static defaultProps = {
-    series: [],
-    zoomable: true,
-    updateYTransformation: () => {},
-    yAxisWidth: 50,
-  };
+  renderAllAxes() {
+    const {
+      axisDisplayMode,
+      series,
+      zoomable,
+      height,
+      updateYTransformation,
+      yAxisWidth,
+      yTransformations,
+    } = this.props;
+    // Make sure that the axes don't appear if we're also going to be rendering
+    // the placeholder axis.
+    let axisOffsetX = this.showCollapsedAxis() ? yAxisWidth : 0;
+    return series
+      .filter(
+        s =>
+          !s.hidden &&
+          (s.yAxisDisplayMode || axisDisplayMode) === AxisDisplayMode.ALL
+      )
+      .map((s, idx) => {
+        if (idx > 0) {
+          axisOffsetX += yAxisWidth;
+        }
+        return (
+          <YAxis
+            key={`y-axis--${s.id}`}
+            offsetx={axisOffsetX}
+            zoomable={s.zoomable !== undefined ? s.zoomable : zoomable}
+            series={s}
+            height={height}
+            width={yAxisWidth}
+            updateYTransformation={updateYTransformation}
+            yTransformation={yTransformations[s.id]}
+          />
+        );
+      });
+  }
 
-  shouldComponentUpdate() {
-    // TODO: Implement
-    return true;
+  renderPlaceholderAxis() {
+    const { axisDisplayMode, height, yAxisWidth, series } = this.props;
+    // The most-specific setting wins.
+    const numCollapsed = this.showCollapsedAxis();
+    // TODO: Should we only do this if there's more than 1?
+    if (numCollapsed) {
+      return (
+        <CollapsedAxis
+          key="y-axis--collapsed"
+          height={height}
+          width={yAxisWidth}
+        />
+      );
+    }
+    return null;
   }
 
   render() {
-    const {
-      width,
-      height,
-      series,
-      zoomable,
-      yAxisWidth,
-      updateYTransformation,
-      yTransformations,
-    } = this.props;
-    let axisOffsetX = 0;
+    const { width, height, onMouseEnter, onMouseLeave } = this.props;
+    const axes = [];
+    axes.push(this.renderPlaceholderAxis());
+    // We need to render all of the axes (even if they're hidden) in order to
+    // keep the zoom states in sync across show/hide toggles.
+    this.renderAllAxes().forEach(axis => {
+      axes.push(axis);
+    });
     return (
-      <svg width={width} height={height}>
-        {series.filter(s => !s.hidden).map((s, idx) => {
-          if (idx > 0) {
-            axisOffsetX += yAxisWidth;
-          }
-          return (
-            <YAxis
-              key={`y-axis--${s.id}`}
-              offsetx={axisOffsetX}
-              zoomable={s.zoomable !== undefined ? s.zoomable : zoomable}
-              series={s}
-              height={height}
-              width={yAxisWidth}
-              updateYTransformation={updateYTransformation}
-              yTransformation={yTransformations[s.id]}
-            />
-          );
-        })}
+      <svg
+        width={width}
+        height={height}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onFocus={onMouseEnter}
+        onBlur={onMouseLeave}
+      >
+        {axes}
       </svg>
     );
   }
 }
+AxisCollection.propTypes = propTypes;
+AxisCollection.defaultProps = defaultProps;
 
 export default props => (
   <ScalerContext.Consumer>

--- a/src/components/AxisCollection/index.js
+++ b/src/components/AxisCollection/index.js
@@ -84,7 +84,7 @@ class AxisCollection extends React.Component {
   }
 
   renderPlaceholderAxis() {
-    const { axisDisplayMode, height, yAxisWidth, series } = this.props;
+    const { height, yAxisWidth } = this.props;
     // The most-specific setting wins.
     const numCollapsed = this.showCollapsedAxis();
     // TODO: Should we only do this if there's more than 1?

--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -10,13 +10,13 @@ import Brush from '../Brush';
 
 export default class ContextChart extends Component {
   static propTypes = {
-    annotations: PropTypes.arrayOf(PropTypes.shape(annotationPropType)),
-    baseDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
-    contextSeries: seriesPropType,
+    width: PropTypes.number.isRequired,
+    annotations: PropTypes.arrayOf(annotationPropType),
     height: PropTypes.number.isRequired,
+    contextSeries: seriesPropType,
+    baseDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
     subDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
     updateSubDomain: PropTypes.func.isRequired,
-    width: PropTypes.number.isRequired,
     zoomable: PropTypes.bool,
   };
 

--- a/src/components/InteractionLayer/index.js
+++ b/src/components/InteractionLayer/index.js
@@ -23,7 +23,7 @@ class InteractionLayer extends React.Component {
     onMouseOut: PropTypes.func,
     updateXTransformation: PropTypes.func,
     series: seriesPropType,
-    annotations: PropTypes.arrayOf(PropTypes.shape(annotationPropType)),
+    annotations: PropTypes.arrayOf(annotationPropType),
     width: PropTypes.number.isRequired,
     subDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
     baseDomain: PropTypes.arrayOf(PropTypes.number).isRequired,

--- a/src/components/LineChart/AxisDisplayMode.js
+++ b/src/components/LineChart/AxisDisplayMode.js
@@ -1,0 +1,10 @@
+const AxisDisplayMode = {
+  ALL: { id: 'ALL', width: (axisWidth, numAxes) => +axisWidth * +numAxes },
+  NONE: { id: 'NONE', width: () => 0 },
+  COLLAPSED: {
+    id: 'COLLAPSED',
+    width: (axisWidth, numAxes = 0) => Math.min(+numAxes, 1) * +axisWidth,
+  },
+};
+
+export default AxisDisplayMode;

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import AxisDisplayMode from '../components/LineChart/AxisDisplayMode';
 
 export const singleSeriePropType = PropTypes.shape({
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
@@ -13,11 +14,12 @@ export const singleSeriePropType = PropTypes.shape({
   y0Accessor: PropTypes.func,
   y1Accessor: PropTypes.func,
   yDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
+  yAxisDisplayMode: AxisDisplayMode,
 });
 
 export const seriesPropType = PropTypes.arrayOf(singleSeriePropType);
 
-export const annotationPropType = {
+export const annotationShape = {
   data: PropTypes.arrayOf(PropTypes.number),
   xScale: PropTypes.func,
   height: PropTypes.number,
@@ -25,6 +27,8 @@ export const annotationPropType = {
   color: PropTypes.string,
   fillOpacity: PropTypes.number,
 };
+
+export const annotationPropType = PropTypes.shape(annotationShape);
 
 export const pointPropType = PropTypes.shape({
   id: PropTypes.number,
@@ -45,4 +49,9 @@ export const rulerPropType = PropTypes.shape({
 export const contextChartPropType = PropTypes.shape({
   visible: PropTypes.bool,
   height: PropTypes.number,
+});
+
+export const axisDisplayModeType = PropTypes.shape({
+  // (axisWidth, numAxes) => (width of all of the axes)
+  width: PropTypes.func.isRequired,
 });

--- a/stories/index.js
+++ b/stories/index.js
@@ -9,6 +9,7 @@ import { action } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
 import { DataProvider, LineChart, Brush } from '../src';
 import quandlLoader from './quandlLoader';
+import AxisDisplayMode from '../src/components/LineChart/AxisDisplayMode';
 
 const randomData = (dt = 100000000, n = 250) => {
   const data = [];
@@ -37,7 +38,7 @@ const staticLoader = ({ id, oldSeries, reason }) => {
   };
 };
 
-const liveLoader = ({ id, oldSeries, baseDomain, reason }) => {
+const liveLoader = ({ id, oldSeries, reason }) => {
   action('LOADER_REQUEST_DATA')(id, reason);
   if (reason === 'MOUNTED') {
     // Create dataset on mount
@@ -414,19 +415,6 @@ storiesOf('LineChart', module)
     ))
   )
   .add(
-    'Without y axis',
-    withInfo()(() => (
-      <DataProvider
-        defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
-        yAxisWidth={0}
-        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
-      >
-        <LineChart height={CHART_HEIGHT} />
-      </DataProvider>
-    ))
-  )
-  .add(
     'Non-Zoomable',
     withInfo()(() => {
       class ZoomToggle extends React.Component {
@@ -654,5 +642,332 @@ storiesOf('LineChart', module)
         }
       }
       return <BrushComponent />;
+    })
+  );
+
+storiesOf('Y-Axis Modes', module)
+  .addDecorator(story => (
+    <div style={{ marginLeft: 'auto', marginRight: 'auto', width: '80%' }}>
+      {story()}
+    </div>
+  ))
+  .add(
+    'Without y axis',
+    withInfo()(() => (
+      <DataProvider
+        defaultLoader={staticLoader}
+        baseDomain={staticBaseDomain}
+        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+      >
+        <LineChart
+          height={CHART_HEIGHT}
+          yAxisDisplayMode={AxisDisplayMode.NONE}
+        />
+      </DataProvider>
+    ))
+  )
+  .add(
+    'Collapsed y axis',
+    withInfo()(() => (
+      <DataProvider
+        defaultLoader={staticLoader}
+        baseDomain={staticBaseDomain}
+        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+      >
+        <LineChart
+          height={CHART_HEIGHT}
+          yAxisDisplayMode={AxisDisplayMode.COLLAPSED}
+        />
+      </DataProvider>
+    ))
+  )
+  .add(
+    'Some hidden',
+    withInfo()(() => {
+      // eslint-disable-next-line
+      class SomeCollapsed extends React.Component {
+        state = {
+          yAxisDisplayMode: AxisDisplayMode.ALL,
+        };
+
+        render() {
+          const { yAxisDisplayMode } = this.state;
+          return (
+            <React.Fragment>
+              <DataProvider
+                defaultLoader={staticLoader}
+                baseDomain={staticBaseDomain}
+                series={[
+                  {
+                    id: 1,
+                    color: 'steelblue',
+                    yAxisDisplayMode: AxisDisplayMode.NONE,
+                  },
+                  {
+                    id: 2,
+                    color: 'maroon',
+                  },
+                  {
+                    id: 3,
+                    color: 'orange',
+                    yAxisDisplayMode: AxisDisplayMode.NONE,
+                  },
+                  { id: 4, color: 'green' },
+                ]}
+              >
+                <LineChart
+                  height={CHART_HEIGHT}
+                  yAxisDisplayMode={yAxisDisplayMode}
+                />
+              </DataProvider>
+              <button
+                onClick={() =>
+                  this.setState({
+                    yAxisDisplayMode: AxisDisplayMode.ALL,
+                  })
+                }
+              >
+                ALL
+              </button>
+              <button
+                onClick={() =>
+                  this.setState({
+                    yAxisDisplayMode: AxisDisplayMode.NONE,
+                  })
+                }
+              >
+                NONE
+              </button>
+              <button
+                onClick={() =>
+                  this.setState({
+                    yAxisDisplayMode: AxisDisplayMode.COLLAPSED,
+                  })
+                }
+              >
+                COLLAPSED
+              </button>
+            </React.Fragment>
+          );
+        }
+      }
+      return <SomeCollapsed />;
+    })
+  )
+  .add(
+    'Some collapsed',
+    withInfo()(() => {
+      // eslint-disable-next-line
+      class SomeCollapsed extends React.Component {
+        state = {
+          yAxisDisplayMode: AxisDisplayMode.ALL,
+        };
+
+        render() {
+          const { yAxisDisplayMode } = this.state;
+          return (
+            <React.Fragment>
+              <DataProvider
+                defaultLoader={staticLoader}
+                baseDomain={staticBaseDomain}
+                series={[
+                  {
+                    id: 1,
+                    color: 'steelblue',
+                    yAxisDisplayMode: AxisDisplayMode.COLLAPSED,
+                  },
+                  {
+                    id: 2,
+                    color: 'maroon',
+                  },
+                  {
+                    id: 3,
+                    color: 'orange',
+                    yAxisDisplayMode: AxisDisplayMode.COLLAPSED,
+                  },
+                  { id: 4, color: 'green' },
+                ]}
+              >
+                <LineChart
+                  height={CHART_HEIGHT}
+                  yAxisDisplayMode={yAxisDisplayMode}
+                />
+              </DataProvider>
+            </React.Fragment>
+          );
+        }
+      }
+      return <SomeCollapsed />;
+    })
+  )
+  .add(
+    'Some collapsed (until hover)',
+    withInfo()(() => {
+      // eslint-disable-next-line
+      class SomeCollapsed extends React.Component {
+        state = {
+          yAxisDisplayMode: AxisDisplayMode.ALL,
+          series: [
+            {
+              id: 1,
+              color: 'steelblue',
+              yAxisDisplayMode: AxisDisplayMode.COLLAPSED,
+            },
+            {
+              id: 2,
+              color: 'maroon',
+            },
+            {
+              id: 3,
+              color: 'orange',
+              yAxisDisplayMode: AxisDisplayMode.COLLAPSED,
+            },
+            { id: 4, color: 'green' },
+          ],
+        };
+
+        toggleAxisMode = () => {
+          const series = this.state.series.map(s => {
+            let yAxisDisplayMode;
+            if (s.id === 1 || s.id === 3) {
+              if (!s.yAxisDisplayMode) {
+                yAxisDisplayMode = AxisDisplayMode.COLLAPSED;
+              }
+            }
+            return {
+              ...s,
+              yAxisDisplayMode,
+            };
+          });
+          this.setState({
+            series,
+          });
+        };
+
+        render() {
+          const { series, yAxisDisplayMode } = this.state;
+          return (
+            <React.Fragment>
+              <DataProvider
+                defaultLoader={staticLoader}
+                baseDomain={staticBaseDomain}
+                series={series}
+              >
+                <LineChart
+                  height={CHART_HEIGHT}
+                  yAxisDisplayMode={yAxisDisplayMode}
+                  onAxisMouseEnter={this.toggleAxisMode}
+                  onAxisMouseLeave={this.toggleAxisMode}
+                />
+              </DataProvider>
+            </React.Fragment>
+          );
+        }
+      }
+      return <SomeCollapsed />;
+    })
+  )
+  .add(
+    'AxisCollection modes (button)',
+    withInfo()(() => {
+      // eslint-disable-next-line
+      class ExpandCollapse extends React.Component {
+        state = {
+          yAxisDisplayMode: AxisDisplayMode.ALL,
+        };
+
+        render() {
+          const { yAxisDisplayMode } = this.state;
+          return (
+            <React.Fragment>
+              <DataProvider
+                defaultLoader={staticLoader}
+                baseDomain={staticBaseDomain}
+                series={[
+                  { id: 1, color: 'steelblue' },
+                  { id: 2, color: 'maroon' },
+                ]}
+              >
+                <LineChart
+                  height={CHART_HEIGHT}
+                  yAxisDisplayMode={yAxisDisplayMode}
+                />
+              </DataProvider>
+              <button
+                onClick={() =>
+                  this.setState({
+                    yAxisDisplayMode: AxisDisplayMode.ALL,
+                  })
+                }
+              >
+                ALL
+              </button>
+              <button
+                onClick={() =>
+                  this.setState({
+                    yAxisDisplayMode: AxisDisplayMode.NONE,
+                  })
+                }
+              >
+                NONE
+              </button>
+              <button
+                onClick={() =>
+                  this.setState({
+                    yAxisDisplayMode: AxisDisplayMode.COLLAPSED,
+                  })
+                }
+              >
+                COLLAPSED
+              </button>
+            </React.Fragment>
+          );
+        }
+      }
+      return <ExpandCollapse />;
+    })
+  )
+  .add(
+    'AxisCollection modes (hover)',
+    withInfo()(() => {
+      // eslint-disable-next-line
+      class ExpandCollapse extends React.Component {
+        state = {
+          yAxisDisplayMode: AxisDisplayMode.COLLAPSED,
+        };
+
+        toggleAxisMode = () => {
+          this.setState({
+            yAxisDisplayMode:
+              this.state.yAxisDisplayMode === AxisDisplayMode.ALL
+                ? AxisDisplayMode.COLLAPSED
+                : AxisDisplayMode.ALL,
+          });
+        };
+
+        render() {
+          const { yAxisDisplayMode } = this.state;
+          return (
+            <React.Fragment>
+              <DataProvider
+                defaultLoader={staticLoader}
+                baseDomain={staticBaseDomain}
+                series={[
+                  { id: 1, color: 'steelblue' },
+                  { id: 2, color: 'maroon' },
+                ]}
+              >
+                <LineChart
+                  height={CHART_HEIGHT}
+                  yAxisDisplayMode={yAxisDisplayMode}
+                  onAxisMouseEnter={this.toggleAxisMode}
+                  onAxisMouseLeave={this.toggleAxisMode}
+                />
+              </DataProvider>
+            </React.Fragment>
+          );
+        }
+      }
+      return <ExpandCollapse />;
     })
   );


### PR DESCRIPTION
Add support for several y-axis display modes:

  ALL: Show all of the axes.
  NONE: Don't show any of the axes.
  COLLAPSED: Hide the real axes and instead render a single generic axis
             without values or color.

This also adds event listeners to AxisCollection, as specified via
onAxisMouseEnter / onAxisMouseExit properties on LineChart.