### PR TITLE
[WIP] Added support for live loading.

### DIFF
--- a/src/components/InteractionLayer/index.js
+++ b/src/components/InteractionLayer/index.js
@@ -74,12 +74,13 @@ class InteractionLayer extends React.Component {
     if (this.props.zoomable !== prevProps.zoomable) {
       this.syncZoomingState();
     }
-    const { subDomain: p } = prevProps;
-    const { subDomain: c } = this.props;
+    const { subDomain: p, baseDomain: prevBaseDomain } = prevProps;
+    const { subDomain: c, baseDomain: curBaseDomain } = this.props;
     if (this.rectSelection.property('__zoom')) {
       // Checking if the existing selection has a current zoom state.
       const { width, subDomain, baseDomain } = this.props;
-      if (!isEqual(p, c) || width !== prevProps.width) {
+      const newBaseDomain = !isEqual(prevBaseDomain, curBaseDomain);
+      if (!isEqual(p, c) || width !== prevProps.width || newBaseDomain) {
         const scale = createXScale(baseDomain, width);
         const selection = subDomain.map(scale);
         const transform = d3.zoomIdentity
@@ -88,9 +89,11 @@ class InteractionLayer extends React.Component {
         const prev = this.rectSelection.property('__zoom');
         // Checking if the difference in x transform is significant
         // This means that something else has zoomed (brush) and we need to update the internals
+        // TODO: This should be optimized
         if (
           Math.abs(prev.k - transform.k) > 0.5 ||
-          Math.abs(prev.x - transform.x) > 50
+          Math.abs(prev.x - transform.x) > 50 ||
+          newBaseDomain
         ) {
           this.rectSelection.property('__zoom', transform);
         }

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -20,7 +20,7 @@ class Scaler extends Component {
 
   state = {
     yDomains: {},
-    subDomain: undefined,
+    subDomain: this.props.dataContext.baseDomain,
     baseDomain: [0, 0],
     yTransformations: {},
   };
@@ -34,14 +34,17 @@ class Scaler extends Component {
       nextPropsDomain[0] !== prevStateDomain[0] ||
       nextPropsDomain[1] !== prevStateDomain[1]
     ) {
-      // TODO: Implement functionality when switching the baseDomain
-      // We can try to keep the same subDomain if it exists, clip it etc
-      // Currently we snap subDomain back to baseDomain and resets the yDomains
-      return {
+      // Keep existing subdomain, calculate new x transformation
+      const updates = {
         baseDomain: nextPropsDomain,
-        subDomain: nextPropsDomain,
-        yDomains: {},
       };
+      const { subDomain } = prevState;
+      if (subDomain && subDomain[1] === prevStateDomain[1]) {
+        // You are looking at the end of the window
+        // Update both subDomain and baseDomain
+        updates.subDomain = [subDomain[0], nextPropsDomain[1]];
+      }
+      return updates;
     }
     return null;
   }


### PR DESCRIPTION
This enables live loading from the data loader.

The `loader` should handle the `INTERVAL` reason and return the existing series + the new datapoint(s). If an `updateInterval` prop is sent to the `DataProvider`, it will change it's internal `baseDomain` to `[t0 + updateInterval, t1 + updateInterval]` and propagate this down. The `Scaler` will look for changes in the `baseDomain`, and if the trailing edge of the current `subDomain` is equal to the trailing edge of the `baseDomain`, it will change it's internal subDomain. Each component will make sure that zooming/brushing will be seamless in this transition.

## Short comings
- Expanding the initial baseDomain will not trigger a lifecycle method. Not really sure how this should be handled, for now I would recommend having a key on the `DataProvider` that includes `${baseDomain[0]}_${baseDomain[1]}` to force a full refresh of the chart when the prop changes. This will trigger the necessary lifecycle methods (`MOUNTED` for the loaders, updating y domains etc). This should be inspected more.

- When your current subDomain goes out of scope (`subDomain[0] < baseDomain[0]`) is doesn't to anything clever other than keep the current view. If you start to zoom you will be snapped back to `subDomain[0] === baseDomain[0]`.

## Discussions

- The loader can chose to omit the points from the old series where `point.timestamp < baseDomain[0]` before returning from the `INTERVAL` clause -- or better yet leave one point to be able to draw a line from the first point and out to the left. These points could be washed away automatically by the `DataProvider`, but I prefer not having `DataProvider` mutate the data and leave that responsibility to the application.

- There could be a separate prop indicating whether it should be a sliding or expanding window, that is if `newBaseDomain = [t0 + dt, t0 + dt]` or `newBaseDomain = [t0, t0 + dt]`. This is currently not implemented.