### PR TITLE
Implementation of custom brush

### DIFF
--- a/src/components/Brush/index.js
+++ b/src/components/Brush/index.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 
 class Brush extends React.Component {
   state = {
-    isDraggingOverlay: false,
-    isDraggingHandleWest: false,
-    isDraggingHandleEast: false,
-    isDraggingSelection: false,
     dragStartOverlay: null,
     dragStartSelection: null,
+    isDraggingHandleEast: false,
+    isDraggingHandleWest: false,
+    isDraggingOverlay: false,
+    isDraggingSelection: false,
   };
 
   componentDidMount() {
@@ -189,18 +189,18 @@ class Brush extends React.Component {
 }
 
 Brush.propTypes = {
-  width: PropTypes.number.isRequired,
+  handleColor: PropTypes.string,
   height: PropTypes.number.isRequired,
+  onUpdateSelection: PropTypes.func.isRequired,
   selection: PropTypes.arrayOf(PropTypes.number).isRequired,
   selectionColor: PropTypes.string,
-  handleColor: PropTypes.string,
-  onUpdateSelection: PropTypes.func.isRequired,
+  width: PropTypes.number.isRequired,
   zoomable: PropTypes.bool,
 };
 
 Brush.defaultProps = {
-  selectionColor: '#777',
   handleColor: 'blue',
+  selectionColor: '#777',
   zoomable: true,
 };
 

--- a/src/components/Brush/index.js
+++ b/src/components/Brush/index.js
@@ -1,6 +1,3 @@
-// Not implemented yet. Should write our own brush component,
-// that's the last thing we're not handling ourselves - will mess up rendering cycle (i think)
-
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -23,6 +20,9 @@ class Brush extends React.Component {
   }
 
   onMouseDownOverlay = e => {
+    if (!this.props.zoomable) {
+      return;
+    }
     this.setState({
       isDraggingOverlay: true,
       dragStartOverlay: e.nativeEvent.offsetX,
@@ -30,18 +30,27 @@ class Brush extends React.Component {
   };
 
   onMouseDownHandleEast = () => {
+    if (!this.props.zoomable) {
+      return;
+    }
     this.setState({
       isDraggingHandleEast: true,
     });
   };
 
   onMouseDownHandleWest = () => {
+    if (!this.props.zoomable) {
+      return;
+    }
     this.setState({
       isDraggingHandleWest: true,
     });
   };
 
   onMouseDownSelection = e => {
+    if (!this.props.zoomable) {
+      return;
+    }
     this.setState({
       isDraggingSelection: true,
       dragStartSelection: e.nativeEvent.offsetX,
@@ -49,12 +58,18 @@ class Brush extends React.Component {
   };
 
   onMouseUpSelection = () => {
+    if (!this.props.zoomable) {
+      return;
+    }
     this.setState({
       isDraggingSelection: false,
     });
   };
 
   onMouseUp = () => {
+    if (!this.props.zoomable) {
+      return;
+    }
     this.setState({
       isDraggingHandleEast: false,
       isDraggingHandleWest: false,
@@ -66,6 +81,9 @@ class Brush extends React.Component {
   };
 
   onMouseMove = e => {
+    if (!this.props.zoomable) {
+      return;
+    }
     if (this.state.isDraggingHandleEast) {
       const position = e.nativeEvent.offsetX;
       const { selection } = this.props;
@@ -116,15 +134,16 @@ class Brush extends React.Component {
   };
 
   render() {
-    const { width, height, selectionColor, handleColor } = this.props;
+    const { width, height, selectionColor, handleColor, zoomable } = this.props;
     const { selection } = this.props;
     const selectionWidth = selection[1] - selection[0];
+    const disabledCursor = zoomable ? null : 'inherit';
     return (
       <g fill="none" stoke="#777" onMouseMove={this.onMouseMove}>
         <rect
           className="overlay"
           pointerEvents="all"
-          cursor="crosshair"
+          cursor={disabledCursor || 'crosshair'}
           x={0}
           y={0}
           width={width}
@@ -133,7 +152,7 @@ class Brush extends React.Component {
         />
         <rect
           className="selection"
-          cursor="move"
+          cursor={disabledCursor || 'move'}
           fill={selectionColor}
           fillOpacity={0.3}
           stroke="#fff"
@@ -146,7 +165,7 @@ class Brush extends React.Component {
         />
         <rect
           className="handle handle--west"
-          cursor="ew-resize"
+          cursor={disabledCursor || 'ew-resize'}
           x={selection[0] - 3}
           y={0}
           width={6}
@@ -156,7 +175,7 @@ class Brush extends React.Component {
         />
         <rect
           className="handle handle-east"
-          cursor="ew-resize"
+          cursor={disabledCursor || 'ew-resize'}
           x={selection[1] - 3}
           y={0}
           width={6}
@@ -176,11 +195,13 @@ Brush.propTypes = {
   selectionColor: PropTypes.string,
   handleColor: PropTypes.string,
   onUpdateSelection: PropTypes.func.isRequired,
+  zoomable: PropTypes.bool,
 };
 
 Brush.defaultProps = {
   selectionColor: '#777',
   handleColor: 'blue',
+  zoomable: true,
 };
 
 export default Brush;

--- a/src/components/Brush/index.js
+++ b/src/components/Brush/index.js
@@ -3,65 +3,160 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as d3 from 'd3';
-import { createXScale } from '../../utils/scale-helpers';
 
 class Brush extends React.Component {
+  state = {
+    isDraggingOverlay: false,
+    isDraggingHandleWest: false,
+    isDraggingHandleEast: false,
+    isDraggingSelection: false,
+    dragStartOverlay: null,
+  };
+
   componentDidMount() {
-    const { width, height } = this.props;
-    this.brush = d3
-      .brushX()
-      .extent([[0, 0], [width, height]])
-      .on('brush end', this.didBrush);
-    this.selection = d3.select(this.brushNode);
-    this.selection.call(this.brush);
+    window.addEventListener('mouseup', this.onMouseUp);
   }
 
-  didBrush = () => {};
+  componentWillUnmount() {
+    window.removeEventListener('mouseup', this.onMouseUp);
+  }
+
+  onMouseDownOverlay = e => {
+    this.setState({
+      isDraggingOverlay: true,
+      dragStartOverlay: e.nativeEvent.offsetX,
+    });
+  };
+
+  onMouseDownHandleEast = () => {
+    this.setState({
+      isDraggingHandleEast: true,
+    });
+  };
+
+  onMouseDownHandleWest = () => {
+    this.setState({
+      isDraggingHandleWest: true,
+    });
+  };
+
+  onMouseDownSelection = () => {
+    this.setState({
+      isDraggingSelection: true,
+    });
+  };
+
+  onMouseUpSelection = () => {
+    this.setState({
+      isDraggingSelection: false,
+    });
+  };
+
+  onMouseUp = () => {
+    this.setState({
+      isDraggingHandleEast: false,
+      isDraggingHandleWest: false,
+      isDraggingOverlay: false,
+      isDraggingSelection: false,
+      dragStartOverlay: null,
+    });
+  };
+
+  onMouseMove = e => {
+    if (this.state.isDraggingHandleEast) {
+      const position = e.nativeEvent.offsetX;
+      const { selection } = this.props;
+      if (position < selection[0]) {
+        this.setState({
+          isDraggingHandleEast: false,
+          isDraggingHandleWest: true,
+        });
+        return;
+      }
+      const newSelection = [selection[0], position];
+      this.props.onUpdateSelection(newSelection);
+    } else if (this.state.isDraggingHandleWest) {
+      const position = e.nativeEvent.offsetX;
+      const { selection } = this.props;
+      if (position > selection[1]) {
+        this.setState({
+          isDraggingHandleWest: false,
+          isDraggingHandleEast: true,
+        });
+        return;
+      }
+      const newSelection = [position, selection[1]];
+      this.onUpdateSelection(newSelection);
+    } else if (this.state.isDraggingSelection) {
+      const { selection } = this.props;
+      const { width } = this.props;
+      const dx = e.nativeEvent.movementX;
+      const newSelection = selection.map(d => d + dx);
+      if (newSelection[0] > 0 && newSelection[1] < width) {
+        this.props.onUpdateSelection(newSelection);
+      }
+    } else if (this.state.isDraggingOverlay) {
+      const { dragStartOverlay } = this.state;
+      const newSelection = [dragStartOverlay, e.nativeEvent.offsetX].sort(
+        (a, b) => a - b
+      );
+      this.props.onUpdateSelection(newSelection);
+    }
+  };
+
+  onUpdateSelection = selection => {
+    this.props.onUpdateSelection(selection);
+  };
 
   render() {
-    const { width, height, selectionColor, baseDomain, subDomain } = this.props;
-    const xScale = createXScale(baseDomain, width);
-    const selection = subDomain.map(xScale);
+    const { width, height, selectionColor, handleColor } = this.props;
+    const { selection } = this.props;
     const selectionWidth = selection[1] - selection[0];
     return (
-      <g pointerEvents="all" ref={this.brushNode}>
+      <g fill="none" stoke="#777" onMouseMove={this.onMouseMove}>
         <rect
           className="overlay"
           pointerEvents="all"
           cursor="crosshair"
+          stroke="#777"
           x={0}
           y={0}
           width={width}
           height={height}
+          onMouseDown={this.onMouseDownOverlay}
         />
         <rect
           className="selection"
           cursor="move"
           fill={selectionColor}
           fillOpacity={0.3}
-          stroke="#777"
+          stroke="#fff"
           shapeRendering="crispEdges"
           width={selectionWidth}
           height={height}
           x={selection[0]}
           y={0}
+          onMouseDown={this.onMouseDownSelection}
         />
         <rect
-          className="handle handle--e"
+          className="handle handle--west"
           cursor="ew-resize"
-          x={selection[0] - 5}
-          y="-3"
-          width={10}
-          height={86}
+          x={selection[0] - 3}
+          y={0}
+          width={6}
+          height={height}
+          fill={handleColor}
+          onMouseDown={this.onMouseDownHandleWest}
         />
         <rect
-          className="handle handle--w"
+          className="handle handle-east"
           cursor="ew-resize"
-          x={selection[1] - 5}
-          y="-3"
-          width={10}
-          height={86}
+          x={selection[1] - 3}
+          y={0}
+          width={6}
+          height={height}
+          fill={handleColor}
+          onMouseDown={this.onMouseDownHandleEast}
         />
       </g>
     );
@@ -71,11 +166,15 @@ class Brush extends React.Component {
 Brush.propTypes = {
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
+  selection: PropTypes.arrayOf(PropTypes.number).isRequired,
   selectionColor: PropTypes.string,
+  handleColor: PropTypes.string,
+  onUpdateSelection: PropTypes.func.isRequired,
 };
 
 Brush.defaultProps = {
   selectionColor: '#777',
+  handleColor: 'blue',
 };
 
 export default Brush;

--- a/src/components/Brush/index.js
+++ b/src/components/Brush/index.js
@@ -174,7 +174,7 @@ class Brush extends React.Component {
           onMouseDown={this.onMouseDownHandleWest}
         />
         <rect
-          className="handle handle-east"
+          className="handle handle--east"
           cursor={disabledCursor || 'ew-resize'}
           x={selection[1] - 3}
           y={0}

--- a/src/components/Brush/index.js
+++ b/src/components/Brush/index.js
@@ -11,6 +11,7 @@ class Brush extends React.Component {
     isDraggingHandleEast: false,
     isDraggingSelection: false,
     dragStartOverlay: null,
+    dragStartSelection: null,
   };
 
   componentDidMount() {
@@ -40,9 +41,10 @@ class Brush extends React.Component {
     });
   };
 
-  onMouseDownSelection = () => {
+  onMouseDownSelection = e => {
     this.setState({
       isDraggingSelection: true,
+      dragStartSelection: e.nativeEvent.offsetX,
     });
   };
 
@@ -59,6 +61,7 @@ class Brush extends React.Component {
       isDraggingOverlay: false,
       isDraggingSelection: false,
       dragStartOverlay: null,
+      dragStartSelection: null,
     });
   };
 
@@ -88,11 +91,15 @@ class Brush extends React.Component {
       const newSelection = [position, selection[1]];
       this.onUpdateSelection(newSelection);
     } else if (this.state.isDraggingSelection) {
-      const { selection } = this.props;
-      const { width } = this.props;
-      const dx = e.nativeEvent.movementX;
+      const { selection, width } = this.props;
+      const { dragStartSelection } = this.state;
+      const position = e.nativeEvent.offsetX;
+      const dx = position - dragStartSelection;
       const newSelection = selection.map(d => d + dx);
-      if (newSelection[0] > 0 && newSelection[1] < width) {
+      if (newSelection[0] >= 0 && newSelection[1] <= width) {
+        this.setState({
+          dragStartSelection: position,
+        });
         this.props.onUpdateSelection(newSelection);
       }
     } else if (this.state.isDraggingOverlay) {
@@ -118,7 +125,6 @@ class Brush extends React.Component {
           className="overlay"
           pointerEvents="all"
           cursor="crosshair"
-          stroke="#777"
           x={0}
           y={0}
           width={width}

--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -10,20 +10,20 @@ import Brush from '../Brush';
 
 export default class ContextChart extends Component {
   static propTypes = {
-    width: PropTypes.number.isRequired,
     annotations: PropTypes.arrayOf(PropTypes.shape(annotationPropType)),
-    height: PropTypes.number.isRequired,
-    contextSeries: seriesPropType,
     baseDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+    contextSeries: seriesPropType,
+    height: PropTypes.number.isRequired,
     subDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
     updateSubDomain: PropTypes.func.isRequired,
+    width: PropTypes.number.isRequired,
     zoomable: PropTypes.bool,
   };
 
   static defaultProps = {
+    annotations: [],
     contextSeries: [],
     zoomable: true,
-    annotations: [],
   };
 
   onUpdateSelection = selection => {
@@ -77,9 +77,9 @@ export const ScaledContextChart = props => (
       <ContextChart
         {...props}
         baseDomain={baseDomain}
+        contextSeries={contextSeries}
         subDomain={subDomain}
         updateSubDomain={updateSubDomain}
-        contextSeries={contextSeries}
       />
     )}
   </ScalerContext.Consumer>

--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import * as d3 from 'd3';
-import isEqual from 'lodash.isequal';
 import ScalerContext from '../../context/Scaler';
 import LineCollection from '../LineCollection';
 import XAxis from '../XAxis';
@@ -37,7 +35,14 @@ export default class ContextChart extends Component {
   };
 
   render() {
-    const { height, width, baseDomain, subDomain, contextSeries } = this.props;
+    const {
+      height,
+      width,
+      baseDomain,
+      subDomain,
+      contextSeries,
+      zoomable,
+    } = this.props;
     const xScale = createXScale(baseDomain, width);
     const selection = subDomain.map(xScale);
     const annotations = this.props.annotations.map(a => (
@@ -58,6 +63,7 @@ export default class ContextChart extends Component {
             height={height}
             selection={selection}
             onUpdateSelection={this.onUpdateSelection}
+            zoomable={zoomable}
           />
         </svg>
         <XAxis width={width} height={50} domain={baseDomain} />

--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -8,7 +8,9 @@ import XAxis from '../XAxis';
 import Annotation from '../Annotation';
 import { createXScale } from '../../utils/scale-helpers';
 import { seriesPropType, annotationPropType } from '../../utils/proptypes';
+import Brush from '../Brush';
 
+// eslint-disable-next-line
 export default class ContextChart extends Component {
   static propTypes = {
     width: PropTypes.number.isRequired,
@@ -17,7 +19,7 @@ export default class ContextChart extends Component {
     contextSeries: seriesPropType,
     baseDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
     subDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
-    updateXTransformation: PropTypes.func.isRequired,
+    updateSubDomain: PropTypes.func.isRequired,
     zoomable: PropTypes.bool,
   };
 
@@ -27,73 +29,17 @@ export default class ContextChart extends Component {
     annotations: [],
   };
 
-  componentDidMount() {
-    const { width, height } = this.props;
-    this.brush = d3
-      .brushX()
-      .extent([[0, 0], [width, height]])
-      .on('brush end', this.didBrush);
-    this.selection = d3.select(this.brushNode);
-    this.selection.call(this.brush);
-    this.selection.call(this.brush.move, [0, width]);
-    this.syncZoomingState();
-  }
-
-  componentDidUpdate(prevProps) {
-    const { baseDomain, subDomain, width } = this.props;
-    this.brush.extent([[0, 0], [this.props.width, this.props.height]]);
+  onUpdateSelection = selection => {
+    const { baseDomain, width } = this.props;
     const xScale = createXScale(baseDomain, width);
-    const selection = subDomain.map(xScale);
-    if (this.brushNode) {
-      if (!this.props.zoomable) {
-        this.selection.call(this.brush);
-        this.selection.call(this.brush.move, selection);
-        this.selection.on('.brush', null);
-      } else {
-        this.selection.call(this.brush.move, selection);
-      }
-    }
-    if (!this.props.zoomable === prevProps.zoomable) {
-      this.syncZoomingState();
-    }
-  }
-
-  syncZoomingState() {
-    if (this.props.zoomable) {
-      this.selection.call(this.brush);
-    } else {
-      this.selection.on('.brush', null);
-    }
-  }
-
-  updateXTransformation() {
-    const { width, subDomain, baseDomain } = this.props;
-    const selection = d3.event.selection || [0, width];
-    const transform = d3.zoomIdentity
-      .scale(width / (selection[1] - selection[0]))
-      .translate(-selection[0], 0);
-    const scale = createXScale(baseDomain, width);
-    const currentSelection = subDomain.map(scale);
-    if (!isEqual(selection, currentSelection)) {
-      this.props.updateXTransformation(transform, width);
-    }
-  }
-
-  didBrush = () => {
-    if (d3.event.sourceEvent && d3.event.sourceEvent.type === 'zoom') {
-      return;
-    }
-    if (!d3.event.sourceEvent) {
-      return;
-    }
-    if (this.props.zoomable) {
-      this.updateXTransformation();
-    }
+    const subDomain = selection.map(xScale.invert).map(Number);
+    this.props.updateSubDomain(subDomain);
   };
 
   render() {
-    const { height, width, baseDomain, contextSeries } = this.props;
+    const { height, width, baseDomain, subDomain, contextSeries } = this.props;
     const xScale = createXScale(baseDomain, width);
+    const selection = subDomain.map(xScale);
     const annotations = this.props.annotations.map(a => (
       <Annotation key={a.id} {...a} height={height} xScale={xScale} />
     ));
@@ -107,10 +53,11 @@ export default class ContextChart extends Component {
             height={height}
             domain={baseDomain}
           />
-          <g
-            ref={r => {
-              this.brushNode = r;
-            }}
+          <Brush
+            width={width}
+            height={height}
+            selection={selection}
+            onUpdateSelection={this.onUpdateSelection}
           />
         </svg>
         <XAxis width={width} height={50} domain={baseDomain} />
@@ -121,12 +68,12 @@ export default class ContextChart extends Component {
 
 export const ScaledContextChart = props => (
   <ScalerContext.Consumer>
-    {({ subDomain, baseDomain, updateXTransformation, contextSeries }) => (
+    {({ subDomain, baseDomain, updateSubDomain, contextSeries }) => (
       <ContextChart
         {...props}
         baseDomain={baseDomain}
         subDomain={subDomain}
-        updateXTransformation={updateXTransformation}
+        updateSubDomain={updateSubDomain}
         contextSeries={contextSeries}
       />
     )}

--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -8,7 +8,6 @@ import { createXScale } from '../../utils/scale-helpers';
 import { seriesPropType, annotationPropType } from '../../utils/proptypes';
 import Brush from '../Brush';
 
-// eslint-disable-next-line
 export default class ContextChart extends Component {
   static propTypes = {
     width: PropTypes.number.isRequired,

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -91,6 +91,17 @@ class Scaler extends Component {
     this.props.dataContext.subDomainChanged(newDomain);
   };
 
+  updateSubDomain = subDomain => {
+    this.setState(
+      {
+        subDomain,
+      },
+      () => {
+        this.props.dataContext.subDomainChanged(subDomain);
+      }
+    );
+  };
+
   updateYTransformation = (key, scaler, height) => {
     const series = this.props.dataContext.series.find(s => s.id === key);
     const newSubDomain = scaler
@@ -115,6 +126,7 @@ class Scaler extends Component {
     const { dataContext } = this.props;
     const ownContext = {
       updateXTransformation: this.updateXTransformation,
+      updateSubDomain: this.updateSubDomain,
       updateYTransformation: this.updateYTransformation,
       yTransformations,
     };

--- a/src/index.js
+++ b/src/index.js
@@ -3,3 +3,4 @@ export { default as ContextChart } from './components/ContextChart';
 export { default as LineChart } from './components/LineChart';
 export { default as Line } from './components/Line';
 export { default as XAxis } from './components/XAxis';
+export { default as Brush } from './components/Brush';

--- a/stories/index.js
+++ b/stories/index.js
@@ -473,7 +473,6 @@ storiesOf('LineChart', module)
       // eslint-disable-next-line
       class BrushComponent extends React.Component {
         state = {
-          baseDomain: [0, width],
           selection: [0, width],
         };
 
@@ -484,17 +483,22 @@ storiesOf('LineChart', module)
         };
 
         render() {
-          const { baseDomain, selection } = this.state;
+          const { selection } = this.state;
           return (
-            <svg width={width} height={height}>
-              <Brush
-                height={height}
-                width={width}
-                baseDomain={baseDomain}
-                selection={selection}
-                onUpdateSelection={this.onUpdateSelection}
-              />
-            </svg>
+            <div>
+              <svg width={width} height={height} stroke="#777">
+                <Brush
+                  height={height}
+                  width={width}
+                  selection={selection}
+                  onUpdateSelection={this.onUpdateSelection}
+                />
+              </svg>
+              <p>width: {width}</p>
+              <p>
+                selection: [{selection[0]}, {selection[1]}]
+              </p>
+            </div>
           );
         }
       }

--- a/stories/index.js
+++ b/stories/index.js
@@ -7,7 +7,7 @@ import 'react-select/dist/react-select.css';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
-import { DataProvider, LineChart } from '../src';
+import { DataProvider, LineChart, Brush } from '../src';
 import quandlLoader from './quandlLoader';
 
 const randomData = () => {
@@ -463,5 +463,41 @@ storiesOf('LineChart', module)
         }
       }
       return <EnableDisableSeries />;
+    })
+  )
+  .add(
+    'Custom context brush',
+    withInfo()(() => {
+      const width = 600;
+      const height = 50;
+      // eslint-disable-next-line
+      class BrushComponent extends React.Component {
+        state = {
+          baseDomain: [0, width],
+          selection: [0, width],
+        };
+
+        onUpdateSelection = selection => {
+          this.setState({
+            selection,
+          });
+        };
+
+        render() {
+          const { baseDomain, selection } = this.state;
+          return (
+            <svg width={width} height={height}>
+              <Brush
+                height={height}
+                width={width}
+                baseDomain={baseDomain}
+                selection={selection}
+                onUpdateSelection={this.onUpdateSelection}
+              />
+            </svg>
+          );
+        }
+      }
+      return <BrushComponent />;
     })
   );


### PR DESCRIPTION
D3’s brush actually updates the DOM - which means that draws to the DOM happens without react knowing about it, hence not being able to be clever about the virtual dom diffing (I think). D3s zoom however only attaches an event listener to a given object and leaves the rest up to the user (great). Also, the zoom events are a lot more complicated to replicate as it handles all kinds of touch events. D3s brush is also a lot more complicated than necessary as it’s built to handle xy zoom which we’re not using.

## TODO:
Debug this with touch events, if that will ever become a use case. Currently — Operation Support is not using the context chart afaik, so there’s no rush there. 