### PR TITLE
Yaxis cursor

### DIFF
--- a/src/components/AxisCollection/YAxis.js
+++ b/src/components/AxisCollection/YAxis.js
@@ -125,9 +125,14 @@ export default class YAxis extends Component {
   }
 
   render() {
-    const { offsetx } = this.props;
+    const { offsetx, zoomable } = this.props;
+    const cursor = zoomable ? 'move' : 'inherit';
     return (
-      <g className="axis-y" transform={`translate(${offsetx}, 0)`}>
+      <g
+        className="axis-y"
+        transform={`translate(${offsetx}, 0)`}
+        cursor={cursor}
+      >
         {this.renderAxis()}
         {this.renderZoomRect()}
       </g>


### PR DESCRIPTION
Give a notion that the yAxis can in fact be scrolled/panned by adding `cursor: move` when zoomable and `inherit` when non-zoomable.