### PR TITLE
Clean up bugs found in the 0.2.0 migration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+package.json

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "lodash.isequal": "^4.5.0",
     "np": "^2.20.1",
     "react-select": "^1.2.1",
-    "react-sizeme": "2.4.3",
-    "styled-components": "^3.2.6"
+    "react-sizeme": "2.4.3"
   },
   "peerDependencies": {
     "react": "16.x"

--- a/src/components/AxisCollection/YAxis.js
+++ b/src/components/AxisCollection/YAxis.js
@@ -92,9 +92,16 @@ export default class YAxis extends Component {
     const k = 1;
     const tickFormat = scale.tickFormat();
     const range = scale.range().map(r => r + halfStrokeWidth);
-    const pathString = `M${k * tickSizeOuter},${range[0]}H${halfStrokeWidth}V${
-      range[1]
-    }H${k * tickSizeOuter}`;
+    const pathString = [
+      // Move to this (x,y); start drawing
+      `M${k * tickSizeOuter},${range[0] - strokeWidth}`,
+      // Draw a horizontal line halfStrokeWidth long
+      `H${halfStrokeWidth}`,
+      // Draw a vertical line from bottom to top
+      `V${range[1]}`,
+      // Finish wwith another horizontal line
+      `H${k * tickSizeOuter}`,
+    ].join('');
     return (
       <g
         className="axis"

--- a/src/components/AxisCollection/YAxis.js
+++ b/src/components/AxisCollection/YAxis.js
@@ -99,7 +99,7 @@ export default class YAxis extends Component {
       `H${halfStrokeWidth}`,
       // Draw a vertical line from bottom to top
       `V${range[1]}`,
-      // Finish wwith another horizontal line
+      // Finish with another horizontal line
       `H${k * tickSizeOuter}`,
     ].join('');
     return (

--- a/src/components/AxisCollection/index.js
+++ b/src/components/AxisCollection/index.js
@@ -6,8 +6,8 @@ import { seriesPropType } from '../../utils/proptypes';
 
 class AxisCollection extends React.Component {
   static propTypes = {
-    height: PropTypes.number.isRequired,
     width: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
     series: seriesPropType,
     zoomable: PropTypes.bool,
     updateYTransformation: PropTypes.func,
@@ -35,11 +35,11 @@ class AxisCollection extends React.Component {
 
   render() {
     const {
+      width,
+      height,
       series,
       zoomable,
       yAxisWidth,
-      height,
-      width,
       updateYTransformation,
       yTransformations,
     } = this.props;

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -199,11 +199,16 @@ export default class DataProvider extends Component {
       pointsPerSeries,
       oldSeries: seriesObject,
       reason,
+    });
+    const loaderConfig = {
+      data: [],
+      id,
+      ...loaderResult,
+      reason,
       yAccessor: seriesObject.yAccessor,
       y0Accessor: seriesObject.y0Accessor,
       y1Accessor: seriesObject.y1Accessor,
-    });
-    const loaderConfig = { data: [], id, ...loaderResult, reason };
+    };
     const stateUpdates = {};
     if (reason === 'MOUNTED') {
       const yDomain = calculateDomainFromData(

--- a/src/components/InteractionLayer/index.js
+++ b/src/components/InteractionLayer/index.js
@@ -159,12 +159,17 @@ class InteractionLayer extends React.Component {
       const xpos = e.nativeEvent.offsetX;
       const ypos = e.nativeEvent.offsetY;
       const rawTimestamp = xScale.invert(xpos).getTime();
+      let notified = false;
       annotations.forEach(a => {
         if (rawTimestamp > a.data[0] && rawTimestamp < a.data[1]) {
           // Clicked within an annotation
           onClickAnnotation(a, xpos, ypos);
+          notified = true;
         }
       });
+      if (notified) {
+        return;
+      }
     }
     if (onClick) {
       onClick(e);

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -24,6 +24,9 @@ const propTypes = {
   series: seriesPropType,
   crosshair: PropTypes.bool,
   onMouseMove: PropTypes.func,
+  onClick: PropTypes.func,
+  // (annotation, x, y) => null
+  onClickAnnotation: PropTypes.func,
   subDomain: PropTypes.arrayOf(PropTypes.number),
   yAxisWidth: PropTypes.number,
   contextChart: contextChartPropType,
@@ -39,6 +42,8 @@ const defaultProps = {
   },
   crosshair: true,
   onMouseMove: null,
+  onClick: null,
+  onClickAnnotation: null,
   series: [],
   annotations: [],
   ruler: {
@@ -78,6 +83,8 @@ class LineChartComponent extends Component {
       subDomain,
       crosshair,
       onMouseMove,
+      onClick,
+      onClickAnnotation,
       zoomable,
       annotations,
       ruler,
@@ -121,9 +128,11 @@ class LineChartComponent extends Component {
               width={chartSize.width}
               crosshair={crosshair}
               onMouseMove={onMouseMove}
+              onClickAnnotation={onClickAnnotation}
               zoomable={zoomable}
               ruler={ruler}
               annotations={annotations}
+              onClick={onClick}
             />
           </svg>
         </div>

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -1,72 +1,77 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import sizeMe from 'react-sizeme';
-import styled from 'styled-components';
 import AxisCollection from '../AxisCollection';
-import XAxis from '../XAxis';
-import { ScaledLineCollection } from '../LineCollection';
-import InteractionLayer from '../InteractionLayer';
 import Scaler from '../Scaler';
 import ScalerContext from '../../context/Scaler';
 import { ScaledContextChart } from '../ContextChart';
 import {
+  contextChartPropType,
   seriesPropType,
   annotationPropType,
   rulerPropType,
 } from '../../utils/proptypes';
+import { ScaledLineCollection } from '../LineCollection';
+import InteractionLayer from '../InteractionLayer';
+import XAxis from '../XAxis';
 
-const Wrapper = styled.div`
-  display: grid;
-  grid-template-columns: 1fr auto;
+const propTypes = {
+  // eslint-disable-next-line react/require-default-props
+  size: PropTypes.shape({ width: PropTypes.number.isRequired }),
+  width: PropTypes.number,
+  height: PropTypes.number.isRequired,
+  zoomable: PropTypes.bool,
+  series: seriesPropType,
+  crosshair: PropTypes.bool,
+  onMouseMove: PropTypes.func,
+  subDomain: PropTypes.arrayOf(PropTypes.number),
+  yAxisWidth: PropTypes.number,
+  contextChart: contextChartPropType,
+  annotations: PropTypes.arrayOf(PropTypes.shape(annotationPropType)),
+  ruler: rulerPropType,
+};
 
-  .handle {
-    width: 6px;
-    fill: rgb(0, 72, 125);
-  }
-`;
-
-const CONTEXTCHART_HEIGHT_PCT = 0.1;
+const defaultProps = {
+  zoomable: true,
+  contextChart: {
+    visible: true,
+    height: 100,
+  },
+  crosshair: true,
+  onMouseMove: null,
+  series: [],
+  annotations: [],
+  ruler: {
+    visible: false,
+    xLabel: () => {},
+    yLabel: () => {},
+  },
+  yAxisWidth: 50,
+  width: 0,
+  subDomain: [],
+};
 
 class LineChartComponent extends Component {
-  static propTypes = {
-    zoomable: PropTypes.bool,
-    size: PropTypes.shape({
-      width: PropTypes.number.isRequired,
-    }).isRequired,
-    height: PropTypes.number.isRequired,
-    series: seriesPropType,
-    crosshair: PropTypes.bool,
-    onMouseMove: PropTypes.func,
-    subDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
-    yAxisWidth: PropTypes.number.isRequired,
-    contextChart: PropTypes.shape({
-      visible: PropTypes.bool.isRequired,
-    }),
-    annotations: PropTypes.arrayOf(PropTypes.shape(annotationPropType)),
-    ruler: rulerPropType,
-  };
-
-  static defaultProps = {
-    zoomable: true,
-    contextChart: {
-      visible: true,
-    },
-    crosshair: true,
-    onMouseMove: null,
-    series: [],
-    annotations: [],
-    ruler: {
-      visible: false,
-      xLabel: () => {},
-      yLabel: () => {},
-    },
-  };
-
   state = {};
+
+  getContextChartHeight = ({ xAxisHeight, height }) => {
+    const { contextChart } = this.props;
+    if (!contextChart || contextChart.visible === false) {
+      // No context chart to show.
+      return 0;
+    }
+
+    if (contextChart.heightPct) {
+      return xAxisHeight + contextChart.heightPct * (height - xAxisHeight);
+    }
+
+    return xAxisHeight + (contextChart.height || 100);
+  };
 
   render() {
     const {
-      size: { width },
+      size: { width: sizeWidth },
+      width: propWidth,
       height,
       series,
       yAxisWidth,
@@ -74,29 +79,46 @@ class LineChartComponent extends Component {
       crosshair,
       onMouseMove,
       zoomable,
-      contextChart,
       annotations,
       ruler,
-      contextChart: { visible },
+      contextChart,
     } = this.props;
     const visibleSeries = series.filter(s => !s.hidden);
-    const axisCollectionWidth = yAxisWidth * visibleSeries.length;
-    const contextHeight = contextChart.visible
-      ? CONTEXTCHART_HEIGHT_PCT * height
-      : 0;
-    const lineCollectionHeight = height - contextHeight;
-    const lineCollectionWidth = width - axisCollectionWidth;
+
+    const width = propWidth || sizeWidth;
+    const xAxisHeight = 50;
+    const axisCollectionSize = {
+      width: yAxisWidth * visibleSeries.length,
+    };
+    const contextChartSpace = this.getContextChartHeight({
+      xAxisHeight,
+      height,
+    });
+    const chartSize = {
+      width: width - axisCollectionSize.width,
+      height: height - xAxisHeight - contextChartSpace,
+    };
+
+    axisCollectionSize.height = chartSize.height;
+
     return (
-      <Wrapper>
-        <div className="lines-container">
-          <svg width={lineCollectionWidth} height={lineCollectionHeight}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `${chartSize.width}px auto`,
+          gridTemplateRows: '1fr auto',
+          height: `${height}px`,
+        }}
+      >
+        <div className="lines-container" style={{ height: '100%' }}>
+          <svg width={chartSize.width} height={chartSize.height}>
             <ScaledLineCollection
-              height={lineCollectionHeight}
-              width={lineCollectionWidth}
+              height={chartSize.height}
+              width={chartSize.width}
             />
             <InteractionLayer
-              height={lineCollectionHeight}
-              width={lineCollectionWidth}
+              height={chartSize.height}
+              width={chartSize.width}
               crosshair={crosshair}
               onMouseMove={onMouseMove}
               zoomable={zoomable}
@@ -105,31 +127,44 @@ class LineChartComponent extends Component {
             />
           </svg>
         </div>
-        <div className="y-axis-container">
+        <div
+          className="y-axis-container"
+          style={{
+            width: `${axisCollectionSize.width}px`,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
           <AxisCollection
-            height={lineCollectionHeight}
-            width={axisCollectionWidth}
             zoomable={zoomable}
+            width={axisCollectionSize.width}
+            height={axisCollectionSize.height}
           />
         </div>
-        <div className="x-axis-container">
-          <XAxis width={lineCollectionWidth} domain={subDomain} />
+        <div className="x-axis-container" style={{ width: '100%' }}>
+          <XAxis domain={subDomain} width={chartSize.width} />
         </div>
         <div />
-        {visible && (
-          <div className="context-container">
+        {contextChart.visible && (
+          <div
+            className="context-container"
+            style={{ display: 'flex', flexDirection: 'column' }}
+          >
             <ScaledContextChart
-              height={contextHeight}
-              width={lineCollectionWidth}
+              height={contextChart.height || 100}
+              width={chartSize.width}
               zoomable={zoomable}
               annotations={annotations}
             />
           </div>
         )}
-      </Wrapper>
+      </div>
     );
   }
 }
+
+LineChartComponent.propTypes = propTypes;
+LineChartComponent.defaultProps = defaultProps;
 
 const SizedLineChartComponent = sizeMe()(LineChartComponent);
 
@@ -147,5 +182,8 @@ const LineChart = props => (
     </ScalerContext.Consumer>
   </Scaler>
 );
+
+LineChart.propTypes = propTypes;
+LineChart.defaultProps = defaultProps;
 
 export default LineChart;

--- a/src/components/XAxis.js
+++ b/src/components/XAxis.js
@@ -45,7 +45,7 @@ function multiFormat(date) {
               : formatYear)(date);
 }
 
-export default class Axis extends Component {
+class Axis extends Component {
   renderAxis() {
     const { domain, width, strokeColor } = this.props;
     const scale = createXScale(domain, width);
@@ -60,9 +60,12 @@ export default class Axis extends Component {
     const k = 1;
     const tickFormat = multiFormat;
     const range = scale.range().map(r => r + halfStrokeWidth);
-    const pathString = `M${range[0]},${k * tickSizeOuter}V${halfStrokeWidth}H${
-      range[1]
-    }V${k * tickSizeOuter}`;
+    const pathString = [
+      `M${range[0]},${k * tickSizeOuter}`,
+      `V${halfStrokeWidth}`,
+      `H${range[1] - strokeWidth}`,
+      `V${k * tickSizeOuter}`,
+    ].join('');
     return (
       <g
         className="x-axis"
@@ -107,3 +110,5 @@ export default class Axis extends Component {
 
 Axis.propTypes = propTypes;
 Axis.defaultProps = defaultProps;
+
+export default Axis;

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -10,6 +10,8 @@ export const singleSeriePropType = PropTypes.shape({
   step: PropTypes.bool,
   xAccessor: PropTypes.func,
   yAccessor: PropTypes.func,
+  y0Accessor: PropTypes.func,
+  y1Accessor: PropTypes.func,
   yDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
 });
 
@@ -38,4 +40,9 @@ export const rulerPropType = PropTypes.shape({
   visible: PropTypes.bool,
   xLabel: PropTypes.func.isRequired,
   yLabel: PropTypes.func.isRequired,
+});
+
+export const contextChartPropType = PropTypes.shape({
+  visible: PropTypes.bool,
+  height: PropTypes.number,
 });

--- a/stories/index.js
+++ b/stories/index.js
@@ -74,6 +74,7 @@ const staticBaseDomain = d3.extent(randomData(), d => d.timestamp);
 const liveBaseDomain = d3.extent(randomData(5000, 50), d => d.timestamp);
 const CHART_HEIGHT = 500;
 
+/* eslint-disable react/no-multi-comp */
 storiesOf('LineChart', module)
   .addDecorator(story => (
     <div style={{ marginLeft: 'auto', marginRight: 'auto', width: '80%' }}>
@@ -93,6 +94,88 @@ storiesOf('LineChart', module)
     ))
   )
   .add(
+    'Sized',
+    withInfo()(() => (
+      <div>
+        <p>All of the components should be entirely contained in the red box</p>
+        <div
+          style={{
+            width: `${CHART_HEIGHT}px`,
+            height: `${CHART_HEIGHT}px`,
+            border: '2px solid red',
+          }}
+        >
+          <DataProvider
+            defaultLoader={staticLoader}
+            baseDomain={staticBaseDomain}
+            series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+          >
+            <LineChart height={CHART_HEIGHT} width={CHART_HEIGHT} />
+          </DataProvider>
+        </div>
+      </div>
+    ))
+  )
+  .add(
+    'Resizing',
+    withInfo()(() => {
+      class ResizingChart extends React.Component {
+        state = { width: CHART_HEIGHT, height: CHART_HEIGHT };
+
+        toggleHide = key => {
+          const { hiddenSeries } = this.state;
+          this.setState({
+            hiddenSeries: {
+              ...hiddenSeries,
+              [key]: !hiddenSeries[key],
+            },
+          });
+        };
+
+        render() {
+          const { width, height } = this.state;
+          const nextWidth =
+            width === CHART_HEIGHT ? CHART_HEIGHT * 2 : CHART_HEIGHT;
+          const nextHeight =
+            height === CHART_HEIGHT ? CHART_HEIGHT * 2 : CHART_HEIGHT;
+          return (
+            <React.Fragment>
+              <p>
+                All of the components should be entirely contained in the red
+                box
+              </p>
+              <button onClick={() => this.setState({ width: nextWidth })}>
+                change to {nextWidth} pixels wide
+              </button>
+              <button onClick={() => this.setState({ height: nextHeight })}>
+                change to {nextHeight} pixels high
+              </button>
+              <div
+                style={{
+                  width: `${width}px`,
+                  height: `${height}px`,
+                  border: '2px solid red',
+                }}
+              >
+                <DataProvider
+                  defaultLoader={staticLoader}
+                  baseDomain={staticBaseDomain}
+                  series={[
+                    { id: 1, color: 'steelblue' },
+                    { id: 2, color: 'maroon' },
+                  ]}
+                >
+                  <LineChart height={height} width={width} />
+                </DataProvider>
+              </div>
+            </React.Fragment>
+          );
+        }
+      }
+      return <ResizingChart />;
+    })
+  )
+  .add(
     'Custom default accessors',
     withInfo()(() => (
       <DataProvider
@@ -105,6 +188,27 @@ storiesOf('LineChart', module)
         <LineChart height={CHART_HEIGHT} />
       </DataProvider>
     ))
+  )
+  .add(
+    'min/max (on DataProvider)',
+    withInfo()(() => {
+      const y0Accessor = d => d[1] - 0.5;
+      const y1Accessor = d => d[1] + 0.5;
+      return (
+        <DataProvider
+          defaultLoader={customAccessorLoader}
+          xAccessor={d => d[0]}
+          yAccessor={d => d[1]}
+          baseDomain={staticBaseDomain}
+          series={[
+            { id: 10, color: 'steelblue', y0Accessor, y1Accessor },
+            { id: 2, color: 'maroon' },
+          ]}
+        >
+          <LineChart height={CHART_HEIGHT} />
+        </DataProvider>
+      );
+    })
   )
   .add(
     'Loading data from api',
@@ -179,7 +283,6 @@ storiesOf('LineChart', module)
     'Specify y domain',
     withInfo()(() => {
       const staticDomain = [-2, 2];
-      // eslint-disable-next-line
       class SpecifyDomain extends React.Component {
         state = { yDomains: {} };
 
@@ -292,7 +395,6 @@ storiesOf('LineChart', module)
   .add(
     'Non-Zoomable',
     withInfo()(() => {
-      // eslint-disable-next-line
       class ZoomToggle extends React.Component {
         state = {
           zoomable: true,
@@ -346,7 +448,6 @@ storiesOf('LineChart', module)
   .add(
     'Dynamic base domain',
     withInfo()(() => {
-      // eslint-disable-next-line
       class DynamicBaseDomain extends React.Component {
         state = {
           baseDomain: staticBaseDomain,

--- a/stories/index.js
+++ b/stories/index.js
@@ -352,6 +352,40 @@ storiesOf('LineChart', module)
     })
   )
   .add(
+    'Click events',
+    withInfo()(() => {
+      const series = staticLoader({
+        id: 1,
+        reason: 'MOUNTED',
+      }).data;
+      const exampleAnnotations = [
+        {
+          id: 1,
+          data: [series[40].timestamp, series[60].timestamp],
+          color: 'black',
+        },
+      ];
+      return (
+        <DataProvider
+          defaultLoader={staticLoader}
+          baseDomain={staticBaseDomain}
+          series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+        >
+          <LineChart
+            height={CHART_HEIGHT}
+            annotations={exampleAnnotations}
+            onClickAnnotation={annotation => {
+              action('annotation click')(annotation);
+            }}
+            onClick={e => {
+              action('chart click')(e);
+            }}
+          />
+        </DataProvider>
+      );
+    })
+  )
+  .add(
     'Draw points',
     withInfo()(() => (
       <DataProvider

--- a/yarn.lock
+++ b/yarn.lock
@@ -2402,7 +2402,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.0.2, buffer@^5.0.3:
+buffer@^5.0.2:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.1.0.tgz#c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe"
   dependencies:
@@ -3142,10 +3142,6 @@ css-animation@1.x, css-animation@^1.2.5, css-animation@^1.3.2:
     babel-runtime "6.x"
     component-classes "^1.2.5"
 
-css-color-keywords@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
-
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -3230,14 +3226,6 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
-
-css-to-react-native@^2.0.3:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.0.tgz#d524ef7f39a2747a8914e86563669ba35b7cf2e7"
-  dependencies:
-    css-color-keywords "^1.0.0"
-    fbjs "^0.8.5"
-    postcss-value-parser "^3.3.0"
 
 css-what@2.1:
   version "2.1.0"
@@ -4745,7 +4733,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.12, fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.12, fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -5491,7 +5479,7 @@ hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
-hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.3.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
@@ -9602,10 +9590,6 @@ react-inspector@^2.2.2:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
-react-is@^16.3.1:
-  version "16.4.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.0.tgz#cc9fdc855ac34d2e7d9d2eb7059bbc240d35ffcf"
-
 react-lazy-load@^3.0.12:
   version "3.0.13"
   resolved "https://registry.yarnpkg.com/react-lazy-load/-/react-lazy-load-3.0.13.tgz#3b0a92d336d43d3f0d73cbe6f35b17050b08b824"
@@ -10995,29 +10979,6 @@ style-loader@^0.20.3:
   dependencies:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
-
-styled-components@^3.2.6:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.3.1.tgz#64ac9c110669123ee133c1d3c1c942b2d119ac30"
-  dependencies:
-    buffer "^5.0.3"
-    css-to-react-native "^2.0.3"
-    fbjs "^0.8.16"
-    hoist-non-react-statics "^2.5.0"
-    is-plain-object "^2.0.1"
-    prop-types "^15.5.4"
-    react-is "^16.3.1"
-    stylis "^3.5.0"
-    stylis-rule-sheet "^0.0.10"
-    supports-color "^3.2.3"
-
-stylis-rule-sheet@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
-
-stylis@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
 
 subarg@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Calculate domain based on y0/y1
If y0Accessor and y1Accessor are specified, use those to calculate the
domain for the chart.

## Remove styled-components
This has disastrous consequences if the user of griff also uses
styled-components, and with a different version (virtually guaranteed).

## sizing
This change also involved an attempt to move to CSS Grid to
automatically determine the components sizes, but without relying on
sizeMe. However, this was aborted for the time being, with some small
sizing remnants hiding in the code. One example is the new contextChart
config, which looks like this:

```
  contextChart: PropTypes.shape({
    // Whether to show the context chart at all.
    visible: PropTypes.bool,
    // How high (in pixels) the context chart should be. Note that an
    // extra 50 pixels will be added for its X axis.
    height: PropTypes.number,
    // How high (in percent of overall height) the context chart should
    // be. Note that 50 pixels is reserved for it X axis height.
    heightPct: PropTypes.number,
  }
```