### PR TITLE
Fixing dynamic base domains

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -124,10 +124,20 @@ export default class DataProvider extends Component {
     // Check if basedomain changed in props -- if so reset state.
     if (!isEqual(this.props.baseDomain, prevProps.baseDomain)) {
       // eslint-disable-next-line
-      this.setState({
-        baseDomain: this.props.baseDomain,
-        subDomain: this.props.baseDomain,
-      });
+      this.setState(
+        {
+          baseDomain: this.props.baseDomain,
+          subDomain: this.props.baseDomain,
+          loaderConfig: {},
+          contextSeries: {},
+          yDomains: {},
+        },
+        async () => {
+          await Promise.map(this.props.series, s =>
+            this.fetchData(s.id, 'MOUNTED')
+          );
+        }
+      );
       if (this.fetchInterval) {
         clearInterval(this.fetchInterval);
       }

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -251,7 +251,7 @@ export default class DataProvider extends Component {
 
   render() {
     const { loaderConfig, contextSeries, baseDomain, subDomain } = this.state;
-    const { yAxisWidth, children, baseDomain: propsBaseDomain } = this.props;
+    const { yAxisWidth, children, baseDomain: externalBaseDomain } = this.props;
     if (Object.keys(loaderConfig).length === 0) {
       // Do not bother, loader hasn't given any data yet.
       return null;
@@ -261,7 +261,7 @@ export default class DataProvider extends Component {
       series: seriesObjects,
       baseDomain,
       // This is used to signal external changes vs internal changes
-      externalBaseDomain: propsBaseDomain,
+      externalBaseDomain,
       subDomain,
       yAxisWidth,
       subDomainChanged: this.subDomainChanged,

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -126,6 +126,7 @@ export default class DataProvider extends Component {
       // eslint-disable-next-line
       this.setState({
         baseDomain: this.props.baseDomain,
+        subDomain: this.props.baseDomain,
       });
       if (this.fetchInterval) {
         clearInterval(this.fetchInterval);
@@ -250,7 +251,7 @@ export default class DataProvider extends Component {
 
   render() {
     const { loaderConfig, contextSeries, baseDomain, subDomain } = this.state;
-    const { yAxisWidth, children } = this.props;
+    const { yAxisWidth, children, baseDomain: propsBaseDomain } = this.props;
     if (Object.keys(loaderConfig).length === 0) {
       // Do not bother, loader hasn't given any data yet.
       return null;
@@ -259,6 +260,8 @@ export default class DataProvider extends Component {
     const context = {
       series: seriesObjects,
       baseDomain,
+      // This is used to signal external changes vs internal changes
+      externalBaseDomain: propsBaseDomain,
       subDomain,
       yAxisWidth,
       subDomainChanged: this.subDomainChanged,

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -71,7 +71,7 @@ class Scaler extends Component {
     } = prevProps;
     if (!isEqual(prevExternalBaseDomain, nextExternalBaseDomain)) {
       // External base domain changed (props on DataProvider)
-      // Reset state effectively.
+      // Reset state
 
       // eslint-disable-next-line
       this.setState({


### PR DESCRIPTION
There was a clash implementing live loading as it introduced another handle whenever the baseDomain changed.

This PR makes `DataProvider` pass down both the `baseDomain` (may be internally updated) and `externalBaseDomain` which is its original prop. Then, the `Scaler` handles a change in `baseDomain` by keeping the subdomain (live loading) and the change in `externalBaseDomain` by resetting its entire state.