### PR TITLE
Ticks amount depends on the width

### DIFF
--- a/src/components/XAxis.js
+++ b/src/components/XAxis.js
@@ -56,7 +56,12 @@ class Axis extends Component {
     const tickSizeOuter = axis.tickSizeOuter();
     const tickSizeInner = axis.tickSizeInner();
     const tickPadding = axis.tickPadding();
-    const values = scale.ticks();
+    // In order to reduce label overlapping for smaller devices
+    // we want to adjust amount of ticks depending on width.
+    // Default amount of ticks is 10 which is sutable for a
+    // regular 1280 display. So by dividing width by ~100
+    // we can achieve appropriate amount of ticks for any width.
+    const values = scale.ticks(Math.floor(width / 100) || 1);
     const k = 1;
     const tickFormat = multiFormat;
     const range = scale.range().map(r => r + halfStrokeWidth);


### PR DESCRIPTION
In opsup we have a problem of overlapping xAxis labels for smaller devices. This is basically because griff relies on d3 [`axis.ticks()`](https://github.com/d3/d3-3.x-api-reference/blob/master/SVG-Axes.md#ticks) which default number is 10 no mater width the chart has. It seems there is no any proper solution over there, so I came up with idea of just passing a number of ticks depending on the width. Better ideas of course are welcome.