### PR TITLE
Ruler touch behavior should differ from hover

### DIFF
--- a/src/components/InteractionLayer/index.js
+++ b/src/components/InteractionLayer/index.js
@@ -120,7 +120,11 @@ class InteractionLayer extends React.Component {
           touchX: null,
           touchY: null,
         });
-      } else {
+      } else if (
+        // ruler should follow points during live loading
+        // except when the chart is dragging firing touchmove event
+        (((d3 || {}).event || {}).sourceEvent || {}).type !== 'touchmove'
+      ) {
         this.setState(
           {
             touchX: newXPos,


### PR DESCRIPTION
To reproduce navigate to 'Live loading and ruler' story. By clicking or touching the chart, ruler should stick with the selected point during live loading. By dragging the chart ruler should stay on the same x position.