### PR TITLE
Check for `area` existence before using it

### DIFF
--- a/src/components/InteractionLayer/index.js
+++ b/src/components/InteractionLayer/index.js
@@ -198,7 +198,7 @@ class InteractionLayer extends React.Component {
     }, 50);
     if (onAreaDefined) {
       const { area } = this.state;
-      if (area.start && area.end && isLargeEnough(area)) {
+      if (area && area.start && area.end && isLargeEnough(area)) {
         onAreaDefined(area);
       }
     }

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -69,5 +69,5 @@ export const areaPropType = PropTypes.shape({
   id: PropTypes.number,
   color: PropTypes.string,
   start: coordinatePropType.isRequired,
-  end: coordinatePropType.isRequired,
+  end: coordinatePropType,
 });

--- a/stories/index.js
+++ b/stories/index.js
@@ -1523,4 +1523,60 @@ storiesOf('InteractionLayer', module)
       }
       return <OnDemandArea />;
     })
+  )
+  .add(
+    'Regression: onMouseUp',
+    withInfo()(() => {
+      // eslint-disable-next-line
+      class OnMouseUp extends React.Component {
+        state = { onAreaDefined: null };
+
+        componentDidMount() {
+          window.setInterval(this.toggleOnAreaDefined, 1000);
+        }
+
+        toggleOnAreaDefined = () => {
+          this.setState({
+            onAreaDefined: this.state.onAreaDefined ? null : console.log,
+          });
+        };
+
+        render() {
+          const { onAreaDefined } = this.state;
+          return (
+            <React.Fragment>
+              <DataProvider
+                defaultLoader={staticLoader}
+                baseDomain={staticBaseDomain}
+                series={[
+                  { id: 1, color: 'steelblue' },
+                  { id: 2, color: 'maroon' },
+                ]}
+              >
+                <LineChart
+                  height={CHART_HEIGHT}
+                  onAreaDefined={onAreaDefined}
+                />
+              </DataProvider>
+              onAreaDefined={onAreaDefined ? 'function' : 'null'}
+              <h2>Test</h2>
+              <ol>
+                <li>
+                  Press and hold when <strong>onAreaDefined</strong> says{' '}
+                  <strong>function</strong>
+                </li>
+                <li>
+                  Continue holding when it switches to <strong>null</strong>
+                </li>
+                <li>
+                  Release when it says <strong>function</strong> again
+                </li>
+                <li>Check that there are no errors in the console</li>
+              </ol>
+            </React.Fragment>
+          );
+        }
+      }
+      return <OnMouseUp />;
+    })
   );


### PR DESCRIPTION
If for some reason we get a mouseup event before we get a mousedown
event, the `area` variable can be null. In this case, we should simply
silently fail instead of crashing.