### PR TITLE
Allow either a string or a number for Area ID

### DIFF
--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -66,7 +66,7 @@ export const coordinatePropType = PropTypes.shape({
 });
 
 export const areaPropType = PropTypes.shape({
-  id: PropTypes.number,
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   color: PropTypes.string,
   start: coordinatePropType.isRequired,
   end: coordinatePropType.isRequired,


### PR DESCRIPTION
The area ID is opaque to griff -- accept either a string or a number.