### PR TITLE
Extract an idPropType

### DIFF
--- a/src/components/Area/index.js
+++ b/src/components/Area/index.js
@@ -25,13 +25,14 @@ const Area = ({ start, end, color, opacity }) => {
 Area.propTypes = {
   color: PropTypes.string,
   start: coordinatePropType.isRequired,
-  end: coordinatePropType.isRequired,
+  end: coordinatePropType,
   opacity: PropTypes.number,
 };
 
 Area.defaultProps = {
   color: '#000',
   opacity: 0.15,
+  end: { xpos: 0, ypos: 0 },
 };
 
 export default Area;

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -1,7 +1,9 @@
 import PropTypes from 'prop-types';
 
+const idPropType = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
 export const singleSeriePropType = PropTypes.shape({
-  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  id: idPropType.isRequired,
   color: PropTypes.string,
   hidden: PropTypes.bool,
   strokeWidth: PropTypes.number,
@@ -34,7 +36,7 @@ export const annotationShape = {
 export const annotationPropType = PropTypes.shape(annotationShape);
 
 export const pointPropType = PropTypes.shape({
-  id: PropTypes.number,
+  id: idPropType,
   name: PropTypes.string,
   color: PropTypes.string,
   timestamp: PropTypes.number,
@@ -66,7 +68,7 @@ export const coordinatePropType = PropTypes.shape({
 });
 
 export const areaPropType = PropTypes.shape({
-  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  id: idPropType,
   color: PropTypes.string,
   start: coordinatePropType.isRequired,
   end: coordinatePropType,


### PR DESCRIPTION
Consolidate all of the `id` props into a single proptype definition --
which can be a number or a string.

Additionally, don't require `Area` to have a start and end property
since this won't happen when the area first pops into existence.