### PR TITLE
Upgrade react-sizeme to 2.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash.isequal": "^4.5.0",
     "np": "^2.20.1",
     "react-select": "^1.2.1",
-    "react-sizeme": "2.4.3"
+    "react-sizeme": "2.4.4"
   },
   "peerDependencies": {
     "react": "16.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9648,9 +9648,9 @@ react-select@^1.2.1:
     prop-types "^15.5.8"
     react-input-autosize "^2.1.2"
 
-react-sizeme@2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.4.3.tgz#0ae872d936646e90415e29b83d8547403265ee53"
+react-sizeme@2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.4.4.tgz#437c2ae82da744dbe40dc589f595e6f70039961d"
   dependencies:
     element-resize-detector "^1.1.12"
     invariant "^2.2.2"


### PR DESCRIPTION
This allegedly fixes the `onShrink`/`onExpand` error, as described in
ctrlplusb/react-sizeme#135