### PR TITLE
Document the branch layout & versioning system

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,18 @@ const loader = ({ id, oldSeries, reason }) => {
 ```
 
 The loader will override the `series` if same keys are provided properties sent to the `DataProvider.`.
+
+## Branches
+
+Active development happens on the `master` branch -- changes here will be published as a prerelease of the N+1 release.
+As of this writing, `master` will eventually become the `0.3.0` release, so its version in `package.json` is `0.3.0-0`.
+
+When it is time cut the `0.3.0` release, a `0.3` branch will be created, and `package.json`'s `version` field will have the prerelease portion removed.
+Then `master`'s `package.json` will be given a version of `0.4.0-0`.
+
+Changes to older versions will need to be merged into release branches as well as the `master` branch, unless it is a specific fix, relevant to only that version.
+
+### Publishing
+
+To publish versions, run `yarn release`.
+This will determine the correct version number, publish the release, and then push the new tag to GitHub.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/griff-react",
-  "version": "0.2.10",
+  "version": "0.2.0",
   "description": "Charting library that relies on React's virtual diffing.",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -21,9 +21,9 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "storybook:build": "build-storybook -c .storybook -o .out",
     "demo:build": "nwb build-react-component src/index.js",
-    "package:deploy": "yarn build && np",
     "lint": "eslint src",
-    "prepush": "yarn lint"
+    "prepush": "yarn lint",
+    "release": "node scripts/publish-release.js"
   },
   "dependencies": {
     "antd": "^3.4.1",
@@ -31,7 +31,6 @@
     "d3": "^4.12.0",
     "immutable": "^3.8.2",
     "lodash.isequal": "^4.5.0",
-    "np": "^2.20.1",
     "react-select": "^1.2.1",
     "react-sizeme": "2.4.4"
   },
@@ -50,12 +49,13 @@
     "nodemon": "^1.17.4",
     "nwb": "^0.21.0",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.2.0",
+    "semver": "^5.5.0"
   },
-  "author": "",
+  "author": "Cognite AS",
   "homepage": "https://griff.surge.sh/",
   "license": "MIT",
-  "repository": "",
+  "repository": "https://github.com/cognitedata/griff-react",
   "keywords": [
     "react-component"
   ],

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+const shell = require('shelljs');
+const semver = require('semver');
+const pkg = require('../package.json');
+
+// Abort on any shell error.
+shell.set('-e');
+
+// See which versions have already been published.}
+
+function getPublishedVersions() {
+  const { name } = pkg;
+  const cmd = `yarn info ${name} versions --json`;
+  const result = shell.exec(cmd, {
+    silent: true,
+    shell: '/bin/bash',
+  });
+  if (result.code !== 0) {
+    console.error(`Unable to fetch versions for ${name}`);
+    console.log(result.stdout);
+    console.error(result.stderr);
+    process.exit(result.code);
+  }
+  try {
+    return JSON.parse(result.stdout).data;
+  } catch (e) {
+    return [];
+  }
+}
+
+function findVersionToBump(currentVersion, versions) {
+  const current = {
+    major: semver.major(currentVersion),
+    minor: semver.minor(currentVersion),
+    patch: semver.patch(currentVersion),
+  };
+  const valid = (versions || getPublishedVersions())
+    .filter(v => semver.major(v) === current.major)
+    .filter(v => semver.minor(v) === current.minor)
+    .sort((a, b) => semver.patch(b) - semver.patch(a))
+    .sort(
+      (a, b) =>
+        (semver.prerelease(b) || [semver.patch(b)])[0] -
+        (semver.prerelease(a) || [semver.patch(a)])[0]
+    );
+  return valid.length ? valid[0] : currentVersion;
+}
+
+const publishedVersion = findVersionToBump(pkg.version);
+
+// Calculate the new version.
+const newVersion = semver.prerelease(publishedVersion)
+  ? semver.inc(publishedVersion, 'prerelease')
+  : semver.inc(publishedVersion, 'patch');
+
+// Publish a new release with this version.
+shell.exec(`yarn publish --new-version "${newVersion}"`);
+
+// Push the version tag to GitHub.
+shell.exec('git push origin --tags');


### PR DESCRIPTION
Document how the branches play together, what the versions will be, and
how to make changes to griff. This also adds a script (run with `yarn
release`) to determine the new version number, publish a release, and
push the tag to GitHub.