### PR TITLE
Added opening animation to lines in a chart

### DIFF
--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -2,103 +2,162 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 
-const Line = ({
-  data,
-  xAccessor,
-  yAccessor,
-  y0Accessor,
-  y1Accessor,
-  xScale,
-  yScale,
-  color,
-  step,
-  hidden,
-  drawPoints,
-  strokeWidth,
-  clipPath,
-}) => {
-  let line;
-  let area;
-  // HTML has an issue with drawing points somewhere in the 30-35M range.
-  // There's no point in drawing pixels more than 30k pixels outside of the range
-  // so this hack will work for a while.
-  // Without this, when zoomed far enough in the line will disappear.
-  const boundedSeries = value => Math.min(Math.max(value, -30000), 30000);
-  if (step) {
-    line = d3
-      .line()
-      .curve(d3.curveStepAfter)
-      .x(d => boundedSeries(xScale(xAccessor(d))))
-      .y(d => boundedSeries(yScale(yAccessor(d))));
-    if (y0Accessor && y1Accessor) {
-      area = d3
-        .area()
+class Line extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      animated: false,
+    };
+  }
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({ animated: true });
+    }, 500);
+  }
+
+  getLineAnimationStyles = () => {
+    if (!this.props.openWithAnimation) {
+      return {};
+    }
+    if (this.pathRef) {
+      if (this.state.animated) {
+        return {
+          transition: 'stroke-dashoffset 2s ease',
+          strokeDasharray: this.pathRef.getTotalLength(),
+          strokeDashoffset: 0,
+          opacity: 1,
+        };
+      }
+      return {
+        strokeDasharray: this.pathRef.getTotalLength(),
+        strokeDashoffset: this.pathRef.getTotalLength(),
+      };
+    }
+
+    return {
+      opacity: 0,
+    };
+  };
+
+  getClipPath = () => {
+    if (this.props.openWithAnimation) {
+      if (this.state.animated) {
+        return 'polygon(0 0, 0 100%, 100% 100%, 100% 0)';
+      }
+      return 'polygon(0 0, 0 100%, 0 100%, 0 0)';
+    }
+    return 'none';
+  };
+
+  render() {
+    const {
+      data,
+      xAccessor,
+      yAccessor,
+      y0Accessor,
+      y1Accessor,
+      xScale,
+      yScale,
+      color,
+      step,
+      hidden,
+      drawPoints,
+      strokeWidth,
+      clipPath,
+    } = this.props;
+
+    let line;
+    let area;
+    // HTML has an issue with drawing points somewhere in the 30-35M range.
+    // There's no point in drawing pixels more than 30k pixels outside of the range
+    // so this hack will work for a while.
+    // Without this, when zoomed far enough in the line will disappear.
+    const boundedSeries = value => Math.min(Math.max(value, -30000), 30000);
+    if (step) {
+      line = d3
+        .line()
         .curve(d3.curveStepAfter)
         .x(d => boundedSeries(xScale(xAccessor(d))))
-        .y0(d => boundedSeries(yScale(y0Accessor(d))))
-        .y1(d => boundedSeries(yScale(y1Accessor(d))));
-    }
-  } else {
-    line = d3
-      .line()
-      .x(d => boundedSeries(xScale(xAccessor(d))))
-      .y(d => boundedSeries(yScale(yAccessor(d))));
-    if (y0Accessor && y1Accessor) {
-      area = d3
-        .area()
+        .y(d => boundedSeries(yScale(yAccessor(d))));
+      if (y0Accessor && y1Accessor) {
+        area = d3
+          .area()
+          .curve(d3.curveStepAfter)
+          .x(d => boundedSeries(xScale(xAccessor(d))))
+          .y0(d => boundedSeries(yScale(y0Accessor(d))))
+          .y1(d => boundedSeries(yScale(y1Accessor(d))));
+      }
+    } else {
+      line = d3
+        .line()
         .x(d => boundedSeries(xScale(xAccessor(d))))
-        .y0(d => boundedSeries(yScale(y0Accessor(d))))
-        .y1(d => boundedSeries(yScale(y1Accessor(d))));
+        .y(d => boundedSeries(yScale(yAccessor(d))));
+      if (y0Accessor && y1Accessor) {
+        area = d3
+          .area()
+          .x(d => boundedSeries(xScale(xAccessor(d))))
+          .y0(d => boundedSeries(yScale(y0Accessor(d))))
+          .y1(d => boundedSeries(yScale(y1Accessor(d))));
+      }
     }
-  }
-  let circles = null;
-  if (drawPoints) {
-    const subDomain = xScale.domain().map(p => p.getTime());
-    circles = data
-      .filter(d => {
-        const x = xAccessor(d);
-        return x >= subDomain[0] && x <= subDomain[1];
-      })
-      .map(d => (
-        <circle
-          key={xAccessor(d)}
-          className="line-circle"
-          r={3}
-          cx={xScale(xAccessor(d))}
-          cy={boundedSeries(yScale(yAccessor(d)))}
-          fill={color}
-        />
-      ));
-  }
-  return (
-    <g clipPath={`url(#${clipPath})`}>
-      {area && (
+    let circles = null;
+    if (drawPoints) {
+      const subDomain = xScale.domain().map(p => p.getTime());
+      circles = data
+        .filter(d => {
+          const x = xAccessor(d);
+          return x >= subDomain[0] && x <= subDomain[1];
+        })
+        .map(d => (
+          <circle
+            key={xAccessor(d)}
+            className="line-circle"
+            r={3}
+            cx={xScale(xAccessor(d))}
+            cy={boundedSeries(yScale(yAccessor(d)))}
+            fill={color}
+          />
+        ));
+    }
+
+    return (
+      <g clipPath={`url(#${clipPath})`}>
+        {area && (
+          <path
+            className="line-area"
+            d={area(data)}
+            style={{
+              stroke: 'none',
+              strokeWidth: `${strokeWidth}px`,
+              transition: 'clip-path 2s ease',
+              clipPath: this.getClipPath(),
+              transformOrigin: 'left center',
+              fill: `${color}`,
+              opacity: 0.25,
+              display: hidden ? 'none' : 'inherit',
+            }}
+          />
+        )}
         <path
-          className="line-area"
-          d={area(data)}
+          ref={ref => {
+            this.pathRef = ref;
+          }}
+          className="line"
+          d={line(data)}
           style={{
-            stroke: 'none',
+            stroke: color,
             strokeWidth: `${strokeWidth}px`,
-            fill: `${color}`,
-            opacity: 0.25,
+            fill: 'none',
             display: hidden ? 'none' : 'inherit',
+            ...this.getLineAnimationStyles(),
           }}
         />
-      )}
-      <path
-        className="line"
-        d={line(data)}
-        style={{
-          stroke: color,
-          strokeWidth: `${strokeWidth}px`,
-          fill: 'none',
-          display: hidden ? 'none' : 'inherit',
-        }}
-      />
-      {circles}
-    </g>
-  );
-};
+        {circles}
+      </g>
+    );
+  }
+}
 
 Line.propTypes = {
   xScale: PropTypes.func.isRequired,
@@ -116,6 +175,7 @@ Line.propTypes = {
   drawPoints: PropTypes.bool,
   strokeWidth: PropTypes.number,
   clipPath: PropTypes.string.isRequired,
+  openWithAnimation: PropTypes.bool,
 };
 
 Line.defaultProps = {
@@ -125,6 +185,7 @@ Line.defaultProps = {
   strokeWidth: 1,
   y0Accessor: null,
   y1Accessor: null,
+  openWithAnimation: false,
 };
 
 export default Line;

--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -16,38 +16,21 @@ class Line extends React.Component {
     }, 500);
   }
 
-  getLineAnimationStyles = () => {
-    if (!this.props.openWithAnimation) {
-      return {};
-    }
-    if (this.pathRef) {
+  getAnimationClipPath = () => {
+    const { openingAnimationDuration } = this.props;
+    if (openingAnimationDuration) {
       if (this.state.animated) {
         return {
-          transition: 'stroke-dashoffset 2s ease',
-          strokeDasharray: this.pathRef.getTotalLength(),
-          strokeDashoffset: 0,
-          opacity: 1,
+          clipPath: 'polygon(0 0, 0 100%, 100% 100%, 100% 0)',
+          transition: `clip-path ${openingAnimationDuration}s ease`,
         };
       }
       return {
-        strokeDasharray: this.pathRef.getTotalLength(),
-        strokeDashoffset: this.pathRef.getTotalLength(),
+        clipPath: 'polygon(0 0, 0 100%, 0 100%, 0 0)',
+        transition: `clip-path ${openingAnimationDuration}s ease`,
       };
     }
-
-    return {
-      opacity: 0,
-    };
-  };
-
-  getClipPath = () => {
-    if (this.props.openWithAnimation) {
-      if (this.state.animated) {
-        return 'polygon(0 0, 0 100%, 100% 100%, 100% 0)';
-      }
-      return 'polygon(0 0, 0 100%, 0 100%, 0 0)';
-    }
-    return 'none';
+    return {};
   };
 
   render() {
@@ -130,12 +113,11 @@ class Line extends React.Component {
             style={{
               stroke: 'none',
               strokeWidth: `${strokeWidth}px`,
-              transition: 'clip-path 2s ease',
-              clipPath: this.getClipPath(),
               transformOrigin: 'left center',
               fill: `${color}`,
               opacity: 0.25,
               display: hidden ? 'none' : 'inherit',
+              ...this.getAnimationClipPath(),
             }}
           />
         )}
@@ -150,7 +132,7 @@ class Line extends React.Component {
             strokeWidth: `${strokeWidth}px`,
             fill: 'none',
             display: hidden ? 'none' : 'inherit',
-            ...this.getLineAnimationStyles(),
+            ...this.getAnimationClipPath(),
           }}
         />
         {circles}
@@ -175,7 +157,7 @@ Line.propTypes = {
   drawPoints: PropTypes.bool,
   strokeWidth: PropTypes.number,
   clipPath: PropTypes.string.isRequired,
-  openWithAnimation: PropTypes.bool,
+  openingAnimationDuration: PropTypes.number,
 };
 
 Line.defaultProps = {
@@ -185,7 +167,7 @@ Line.defaultProps = {
   strokeWidth: 1,
   y0Accessor: null,
   y1Accessor: null,
-  openWithAnimation: false,
+  openingAnimationDuration: null,
 };
 
 export default Line;

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -58,6 +58,9 @@ const propTypes = {
   onAreaDefined: PropTypes.func,
   // (area, xpos, ypos) => shouldContinue
   onAreaClicked: PropTypes.func,
+  // Whether or not to animate the lines on load
+  // of a single line (including when a new line gets added)
+  openWithAnimation: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -86,6 +89,7 @@ const defaultProps = {
   areas: [],
   onAreaDefined: null,
   onAreaClicked: null,
+  openWithAnimation: false,
 };
 
 class LineChartComponent extends Component {
@@ -147,6 +151,7 @@ class LineChartComponent extends Component {
       areas,
       onAreaDefined,
       onAreaClicked,
+      openWithAnimation,
     } = this.props;
 
     const width = propWidth || sizeWidth;
@@ -178,6 +183,7 @@ class LineChartComponent extends Component {
         <div className="lines-container" style={{ height: '100%' }}>
           <svg width={chartSize.width} height={chartSize.height}>
             <ScaledLineCollection
+              openWithAnimation={openWithAnimation}
               height={chartSize.height}
               width={chartSize.width}
             />

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -60,7 +60,7 @@ const propTypes = {
   onAreaClicked: PropTypes.func,
   // Whether or not to animate the lines on load
   // of a single line (including when a new line gets added)
-  openWithAnimation: PropTypes.bool,
+  openingAnimationDuration: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -89,7 +89,7 @@ const defaultProps = {
   areas: [],
   onAreaDefined: null,
   onAreaClicked: null,
-  openWithAnimation: false,
+  openingAnimationDuration: false,
 };
 
 class LineChartComponent extends Component {
@@ -151,7 +151,7 @@ class LineChartComponent extends Component {
       areas,
       onAreaDefined,
       onAreaClicked,
-      openWithAnimation,
+      openingAnimationDuration,
     } = this.props;
 
     const width = propWidth || sizeWidth;
@@ -183,7 +183,7 @@ class LineChartComponent extends Component {
         <div className="lines-container" style={{ height: '100%' }}>
           <svg width={chartSize.width} height={chartSize.height}>
             <ScaledLineCollection
-              openWithAnimation={openWithAnimation}
+              openingAnimationDuration={openingAnimationDuration}
               height={chartSize.height}
               width={chartSize.width}
             />

--- a/src/components/LineCollection/index.js
+++ b/src/components/LineCollection/index.js
@@ -6,7 +6,7 @@ import ScalerContext from '../../context/Scaler';
 import Line from '../Line';
 
 const LineCollection = props => {
-  const { series, width, height, domain, openWithAnimation } = props;
+  const { series, width, height, domain, openingAnimationDuration } = props;
   const xScale = createXScale(domain, width);
   const clipPath = `clip-path-${series
     .filter(s => !s.hidden)
@@ -16,7 +16,7 @@ const LineCollection = props => {
     const yScale = createYScale(s.yDomain, height);
     return (
       <Line
-        openWithAnimation={openWithAnimation}
+        openingAnimationDuration={openingAnimationDuration}
         key={s.id}
         {...s}
         xScale={xScale}
@@ -40,13 +40,13 @@ LineCollection.propTypes = {
   height: PropTypes.number.isRequired,
   series: seriesPropType,
   domain: PropTypes.arrayOf(PropTypes.number),
-  openWithAnimation: PropTypes.bool,
+  openingAnimationDuration: PropTypes.bool,
 };
 
 LineCollection.defaultProps = {
   series: [],
   domain: [0, 0],
-  openWithAnimation: false,
+  openingAnimationDuration: null,
 };
 
 export default LineCollection;

--- a/src/components/LineCollection/index.js
+++ b/src/components/LineCollection/index.js
@@ -6,7 +6,7 @@ import ScalerContext from '../../context/Scaler';
 import Line from '../Line';
 
 const LineCollection = props => {
-  const { series, width, height, domain } = props;
+  const { series, width, height, domain, openWithAnimation } = props;
   const xScale = createXScale(domain, width);
   const clipPath = `clip-path-${series
     .filter(s => !s.hidden)
@@ -16,6 +16,7 @@ const LineCollection = props => {
     const yScale = createYScale(s.yDomain, height);
     return (
       <Line
+        openWithAnimation={openWithAnimation}
         key={s.id}
         {...s}
         xScale={xScale}
@@ -39,11 +40,13 @@ LineCollection.propTypes = {
   height: PropTypes.number.isRequired,
   series: seriesPropType,
   domain: PropTypes.arrayOf(PropTypes.number),
+  openWithAnimation: PropTypes.bool,
 };
 
 LineCollection.defaultProps = {
   series: [],
   domain: [0, 0],
+  openWithAnimation: false,
 };
 
 export default LineCollection;

--- a/stories/index.js
+++ b/stories/index.js
@@ -120,6 +120,18 @@ storiesOf('LineChart', module)
     ))
   )
   .add(
+    'Basic with animation',
+    withInfo()(() => (
+      <DataProvider
+        defaultLoader={staticLoader}
+        baseDomain={staticBaseDomain}
+        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+      >
+        <LineChart height={CHART_HEIGHT} openWithAnimation />
+      </DataProvider>
+    ))
+  )
+  .add(
     'Multiple',
     withInfo()(() => (
       <React.Fragment>

--- a/stories/index.js
+++ b/stories/index.js
@@ -3,6 +3,7 @@ import * as d3 from 'd3';
 import moment from 'moment';
 import Select from 'react-select';
 import isEqual from 'lodash.isequal';
+import debounce from 'lodash.debounce';
 import 'react-select/dist/react-select.css';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
@@ -121,15 +122,149 @@ storiesOf('LineChart', module)
   )
   .add(
     'Basic with animation',
-    withInfo()(() => (
-      <DataProvider
-        defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
-        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
-      >
-        <LineChart height={CHART_HEIGHT} openWithAnimation />
-      </DataProvider>
-    ))
+    withInfo()(() => {
+      class AnimChart extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            animSpeed: 4,
+            series: [
+              { id: 1, color: 'steelblue' },
+              {
+                id: 2,
+                color: 'maroon',
+              },
+            ],
+          };
+
+          this.reloadGraph = debounce(this.reloadGraph, 2000);
+        }
+
+        reloadGraph = () => {
+          this.setState({
+            series: [{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }],
+          });
+        };
+
+        render() {
+          const { animSpeed } = this.state;
+          return (
+            <div>
+              <DataProvider
+                defaultLoader={staticLoader}
+                baseDomain={staticBaseDomain}
+                series={this.state.series}
+              >
+                <LineChart
+                  height={CHART_HEIGHT}
+                  openingAnimationDuration={animSpeed}
+                />
+              </DataProvider>
+              <br />
+              Animation speed: <br />
+              <input
+                type="range"
+                id="animSpeed"
+                name="animSpeed"
+                min="1"
+                max="20"
+                value={animSpeed}
+                step="1"
+                onChange={e => {
+                  this.setState({
+                    animSpeed: +e.target.value,
+                    series: [{ id: 1, color: 'steelblue' }],
+                  });
+                  this.reloadGraph();
+                }}
+              />
+              {animSpeed}
+            </div>
+          );
+        }
+      }
+      return <AnimChart />;
+    })
+  )
+  .add(
+    'MinMax with animation',
+    withInfo()(() => {
+      class AnimChart extends React.Component {
+        constructor(props) {
+          super(props);
+          this.y0Accessor = d => d[1] - 0.5;
+          this.y1Accessor = d => d[1] + 0.5;
+          this.state = {
+            animSpeed: 4,
+            series: [
+              { id: 1, color: 'steelblue' },
+              {
+                id: 2,
+                color: 'maroon',
+                y0Accessor: this.y0Accessor,
+                y1Accessor: this.y1Accessor,
+              },
+            ],
+          };
+
+          this.reloadGraph = debounce(this.reloadGraph, 2000);
+        }
+
+        reloadGraph = () => {
+          this.setState({
+            series: [
+              { id: 1, color: 'steelblue' },
+              {
+                id: 2,
+                color: 'maroon',
+                y0Accessor: this.y0Accessor,
+                y1Accessor: this.y1Accessor,
+              },
+            ],
+          });
+        };
+
+        render() {
+          const { animSpeed } = this.state;
+          return (
+            <div>
+              <DataProvider
+                defaultLoader={customAccessorLoader}
+                xAccessor={d => d[0]}
+                yAccessor={d => d[1]}
+                baseDomain={staticBaseDomain}
+                series={this.state.series}
+              >
+                <LineChart
+                  height={CHART_HEIGHT}
+                  openingAnimationDuration={animSpeed}
+                />
+              </DataProvider>
+              <br />
+              Animation speed: <br />
+              <input
+                type="range"
+                id="animSpeed"
+                name="animSpeed"
+                min="1"
+                max="20"
+                value={animSpeed}
+                step="1"
+                onChange={e => {
+                  this.setState({
+                    animSpeed: +e.target.value,
+                    series: [{ id: 1, color: 'steelblue' }],
+                  });
+                  this.reloadGraph();
+                }}
+              />
+              {animSpeed}
+            </div>
+          );
+        }
+      }
+      return <AnimChart />;
+    })
   )
   .add(
     'Multiple',


### PR DESCRIPTION
Added a prop to the LineChart called 'openWithAnimation'.

This should animate both the line and the area smoothly