### PR TITLE
Don't render area if points are drawn

### DIFF
--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -30,7 +30,7 @@ const Line = ({
       .curve(d3.curveStepAfter)
       .x(d => boundedSeries(xScale(xAccessor(d))))
       .y(d => boundedSeries(yScale(yAccessor(d))));
-    if (y0Accessor && y1Accessor) {
+    if (!drawPoints && y0Accessor && y1Accessor) {
       area = d3
         .area()
         .curve(d3.curveStepAfter)
@@ -43,7 +43,7 @@ const Line = ({
       .line()
       .x(d => boundedSeries(xScale(xAccessor(d))))
       .y(d => boundedSeries(yScale(yAccessor(d))));
-    if (y0Accessor && y1Accessor) {
+    if (!drawPoints && y0Accessor && y1Accessor) {
       area = d3
         .area()
         .x(d => boundedSeries(xScale(xAccessor(d))))

--- a/stories/LineChart.stories.js
+++ b/stories/LineChart.stories.js
@@ -245,6 +245,27 @@ storiesOf('LineChart', module)
     })
   )
   .add(
+    'min/max with raw points',
+    withInfo()(() => {
+      const y0Accessor = d => d[1] - 0.5;
+      const y1Accessor = d => d[1] + 0.5;
+      return (
+        <DataProvider
+          defaultLoader={customAccessorLoader}
+          xAccessor={d => d[0]}
+          yAccessor={d => d[1]}
+          baseDomain={staticBaseDomain}
+          series={[
+            { id: 10, color: 'steelblue', y0Accessor, y1Accessor },
+            { id: 2, color: 'maroon', drawPoints: true },
+          ]}
+        >
+          <LineChart height={CHART_HEIGHT} />
+        </DataProvider>
+      );
+    })
+  )
+  .add(
     'Loading data from api',
     withInfo()(() => (
       <DataProvider


### PR DESCRIPTION
If raw points are going to be drawn, then don't also draw the min/max
uncertainty area.