### PR TITLE
Add support for series collections

### DIFF
--- a/src/components/AxisCollection/index.js
+++ b/src/components/AxisCollection/index.js
@@ -3,13 +3,17 @@ import PropTypes from 'prop-types';
 import CollapsedAxis from './CollapsedAxis';
 import YAxis from './YAxis';
 import ScalerContext from '../../context/Scaler';
-import { seriesPropType, axisDisplayModeType } from '../../utils/proptypes';
+import GriffPropTypes, {
+  seriesPropType,
+  axisDisplayModeType,
+} from '../../utils/proptypes';
 import AxisDisplayMode from '../LineChart/AxisDisplayMode';
 
 const propTypes = {
   height: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,
   series: seriesPropType,
+  collections: GriffPropTypes.collections,
   zoomable: PropTypes.bool,
   updateYTransformation: PropTypes.func,
   yAxisWidth: PropTypes.number,
@@ -27,6 +31,7 @@ const propTypes = {
 
 const defaultProps = {
   series: [],
+  collections: [],
   zoomable: true,
   updateYTransformation: () => {},
   yAxisWidth: 50,
@@ -47,6 +52,7 @@ class AxisCollection extends React.Component {
 
   renderAllVisibleAxes() {
     const {
+      collections,
       series,
       zoomable,
       height,
@@ -54,26 +60,62 @@ class AxisCollection extends React.Component {
       yAxisWidth,
       yTransformations,
     } = this.props;
-    let axisOffsetX = 0;
-    return series.filter(this.axisFilter(AxisDisplayMode.ALL)).map((s, idx) => {
-      if (idx > 0) {
-        axisOffsetX += yAxisWidth;
-      }
-      return (
-        <YAxis
-          key={`y-axis--${s.id}`}
-          offsetx={axisOffsetX}
-          zoomable={s.zoomable !== undefined ? s.zoomable : zoomable}
-          series={s}
-          height={height}
-          width={yAxisWidth}
-          updateYTransformation={updateYTransformation}
-          yTransformation={yTransformations[s.id]}
-          onMouseEnter={this.onAxisMouseEnter(s.id)}
-          onMouseLeave={this.onAxisMouseLeave(s.id)}
-        />
+    let axisOffsetX = -yAxisWidth;
+    return []
+      .concat(
+        series
+          .filter(s => !s.collectionId)
+          .filter(this.axisFilter(AxisDisplayMode.ALL))
+          .map(s => {
+            axisOffsetX += yAxisWidth;
+            return (
+              <YAxis
+                key={`y-axis--${s.id}`}
+                offsetx={axisOffsetX}
+                zoomable={s.zoomable !== undefined ? s.zoomable : zoomable}
+                series={s}
+                height={height}
+                width={yAxisWidth}
+                updateYTransformation={updateYTransformation}
+                yTransformation={yTransformations[s.id]}
+                onMouseEnter={this.onAxisMouseEnter(s.id)}
+                onMouseLeave={this.onAxisMouseLeave(s.id)}
+              />
+            );
+          })
+      )
+      .concat(
+        collections.filter(this.axisFilter(AxisDisplayMode.ALL)).map(c => {
+          axisOffsetX += yAxisWidth;
+
+          const updateCollectionYTransformation = (
+            collectionId,
+            transformation
+          ) => {
+            series.filter(s => s.collectionId === collectionId).forEach(s => {
+              updateYTransformation(s.id, transformation, height);
+            });
+          };
+
+          const yTransformation =
+            yTransformations[series.find(s => s.collectionId === c.id).id];
+
+          return (
+            <YAxis
+              key={`y-axis-collection-${c.id}`}
+              offsetx={axisOffsetX}
+              zoomable={c.zoomable !== undefined ? c.zoomable : zoomable}
+              collection={c}
+              height={height}
+              width={yAxisWidth}
+              updateYTransformation={updateCollectionYTransformation}
+              yTransformation={yTransformation}
+              onMouseEnter={this.onAxisMouseEnter(c.id)}
+              onMouseLeave={this.onAxisMouseLeave(c.id)}
+            />
+          );
+        })
       );
-    });
   }
 
   renderPlaceholderAxis() {
@@ -118,9 +160,16 @@ AxisCollection.defaultProps = defaultProps;
 
 export default props => (
   <ScalerContext.Consumer>
-    {({ series, yAxisWidth, updateYTransformation, yTransformations }) => (
+    {({
+      collections,
+      series,
+      yAxisWidth,
+      updateYTransformation,
+      yTransformations,
+    }) => (
       <AxisCollection
         {...props}
+        collections={collections}
         series={series}
         yAxisWidth={yAxisWidth}
         updateYTransformation={updateYTransformation}

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -5,7 +5,7 @@ import AxisCollection from '../AxisCollection';
 import Scaler from '../Scaler';
 import ScalerContext from '../../context/Scaler';
 import { ScaledContextChart } from '../ContextChart';
-import {
+import GriffPropTypes, {
   areaPropType,
   contextChartPropType,
   seriesPropType,
@@ -27,6 +27,7 @@ const propTypes = {
   height: PropTypes.number,
   zoomable: PropTypes.bool,
   series: seriesPropType,
+  collections: GriffPropTypes.collections,
   crosshair: PropTypes.bool,
   onMouseMove: PropTypes.func,
   onClick: PropTypes.func,
@@ -74,6 +75,7 @@ const defaultProps = {
   onClickAnnotation: null,
   onDoubleClick: null,
   series: [],
+  collections: [],
   annotations: [],
   ruler: {
     visible: false,
@@ -110,15 +112,20 @@ class LineChartComponent extends Component {
   };
 
   getYAxisCollectionWidth = () => {
-    const { yAxisDisplayMode, series, yAxisWidth } = this.props;
+    const { collections, series, yAxisDisplayMode, yAxisWidth } = this.props;
     const counts = {};
-    series.forEach(s => {
-      if (s.hidden) {
+    const addCount = item => {
+      if (item.hidden) {
         return;
       }
-      const mode = (s.yAxisDisplayMode || yAxisDisplayMode).id;
+      if (item.collectionId) {
+        return;
+      }
+      const mode = (item.yAxisDisplayMode || yAxisDisplayMode).id;
       counts[mode] = (counts[mode] || 0) + 1;
-    });
+    };
+    series.forEach(addCount);
+    collections.forEach(addCount);
     const w1 = AxisDisplayMode.ALL.width(
       yAxisWidth,
       counts[AxisDisplayMode.ALL.id] || 0
@@ -252,12 +259,13 @@ const SizedLineChartComponent = sizeMe({ monitorHeight: true })(
 const LineChart = props => (
   <Scaler>
     <ScalerContext.Consumer>
-      {({ yAxisWidth, series, subDomain }) => (
+      {({ collections, series, subDomain, yAxisWidth }) => (
         <SizedLineChartComponent
           {...props}
-          yAxisWidth={yAxisWidth}
+          collections={collections}
           series={series}
           subDomain={subDomain}
+          yAxisWidth={yAxisWidth}
         />
       )}
     </ScalerContext.Consumer>

--- a/src/components/LineCollection/index.js
+++ b/src/components/LineCollection/index.js
@@ -4,14 +4,20 @@ import { createYScale, createXScale } from '../../utils/scale-helpers';
 import { seriesPropType } from '../../utils/proptypes';
 import ScalerContext from '../../context/Scaler';
 import Line from '../Line';
+import AxisDisplayMode from '../LineChart/AxisDisplayMode';
 
 const LineCollection = props => {
   const { series, width, height, domain } = props;
   const xScale = createXScale(domain, width);
   const clipPath = `clip-path-${series
     .filter(s => !s.hidden)
-    .map(s => s.id)
-    .join('-')}`;
+    .map(
+      s =>
+        `${s.id}-${s.collectionId || 0}-${
+          (s.yAxisDisplayMode || AxisDisplayMode.ALL).id
+        }`
+    )
+    .join('/')}`;
   const lines = series.filter(s => !s.hidden).map(s => {
     const yScale = createYScale(s.yDomain, height);
     return (

--- a/src/context/Data.js
+++ b/src/context/Data.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 export default React.createContext({
   series: [],
+  collections: [],
   baseDomain: [Date.now() - 1000 * 60 * 60 * 24 * 365, 0],
   yAxisWidth: 50,
   contextSeries: [],

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types';
+import { AxisDisplayMode } from '../';
 
 const idPropType = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
 
 export const singleSeriePropType = PropTypes.shape({
   id: idPropType.isRequired,
+  collectionId: idPropType.isRequired,
   color: PropTypes.string,
   hidden: PropTypes.bool,
   strokeWidth: PropTypes.number,
@@ -73,3 +75,27 @@ export const areaPropType = PropTypes.shape({
   start: coordinatePropType.isRequired,
   end: coordinatePropType,
 });
+
+class GriffPropTypes {
+  static collection = PropTypes.shape({
+    id: idPropType.isRequired,
+    color: PropTypes.string.isRequired,
+    drawPoints: PropTypes.bool,
+    hidden: PropTypes.bool,
+    strokeWidth: PropTypes.number,
+    xAccessor: PropTypes.func,
+    yAxisDisplayMode: PropTypes.instanceOf(AxisDisplayMode),
+    yAccessor: PropTypes.func,
+    y0Accessor: PropTypes.func,
+    y1Accessor: PropTypes.func,
+    yDomain: PropTypes.arrayOf(PropTypes.number),
+  });
+
+  static collections = PropTypes.arrayOf(GriffPropTypes.collection);
+
+  static singleSeries = singleSeriePropType;
+
+  static multipleSeries = PropTypes.arrayOf(GriffPropTypes.singleSeries);
+}
+
+export default GriffPropTypes;

--- a/stories/SeriesCollections.stories.js
+++ b/stories/SeriesCollections.stories.js
@@ -1,0 +1,186 @@
+import React from 'react';
+import 'react-select/dist/react-select.css';
+import { storiesOf } from '@storybook/react';
+import { AxisDisplayMode, DataProvider, LineChart } from '../src';
+import { staticLoader } from './loaders';
+
+const staticBaseDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
+const CHART_HEIGHT = 500;
+
+storiesOf('Series Collections', module)
+  .add('Single collection', () => (
+    <DataProvider
+      baseDomain={staticBaseDomain}
+      defaultLoader={staticLoader}
+      xAccessor={d => d.timestamp}
+      yAccessor={d => d.value}
+      series={[
+        { id: 1, collectionId: '1+2', color: 'steelblue', name: 'name1' },
+        { id: 2, collectionId: '1+2', color: 'maroon', name: 'name2' },
+      ]}
+      collections={[{ id: '1+2', color: 'red' }]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>
+  ))
+  .add('Mixed items', () => (
+    <DataProvider
+      baseDomain={staticBaseDomain}
+      defaultLoader={staticLoader}
+      xAccessor={d => d.timestamp}
+      yAccessor={d => d.value}
+      series={[
+        { id: 1, collectionId: '1+2', color: 'steelblue', name: 'name1' },
+        { id: 2, collectionId: '1+2', color: 'maroon', name: 'name2' },
+        { id: 3, color: 'orange', name: 'name3' },
+      ]}
+      collections={[{ id: '1+2', color: 'red' }]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>
+  ))
+  .add('Properties by default', () => [
+    <DataProvider
+      key="drawPoints"
+      baseDomain={staticBaseDomain}
+      defaultLoader={staticLoader}
+      xAccessor={d => d.timestamp}
+      yAccessor={d => d.value}
+      series={[
+        { id: 1, collectionId: '1+2', color: 'steelblue', name: 'name1' },
+        { id: 2, collectionId: '1+2', color: 'maroon', name: 'name2' },
+      ]}
+      collections={[{ id: '1+2', color: 'red', drawPoints: true }]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>,
+    <DataProvider
+      key="strokeWidth"
+      baseDomain={staticBaseDomain}
+      defaultLoader={staticLoader}
+      xAccessor={d => d.timestamp}
+      yAccessor={d => d.value}
+      series={[
+        { id: 1, collectionId: '1+2', color: 'steelblue', name: 'name1' },
+        { id: 2, collectionId: '1+2', color: 'maroon', name: 'name2' },
+      ]}
+      collections={[{ id: '1+2', color: 'red', strokeWidth: 3 }]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>,
+    <DataProvider
+      key="yAxisDisplayMode"
+      baseDomain={staticBaseDomain}
+      defaultLoader={staticLoader}
+      xAccessor={d => d.timestamp}
+      yAccessor={d => d.value}
+      series={[
+        { id: 1, collectionId: '1+2', color: 'steelblue', name: 'name1' },
+        { id: 2, collectionId: '1+2', color: 'maroon', name: 'name2' },
+      ]}
+      collections={[
+        { id: '1+2', color: 'red', yAxisDisplayMode: AxisDisplayMode.NONE },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>,
+    <DataProvider
+      key="yDomain"
+      baseDomain={staticBaseDomain}
+      defaultLoader={staticLoader}
+      xAccessor={d => d.timestamp}
+      yAccessor={d => d.value}
+      series={[
+        { id: 1, collectionId: '1+2', color: 'steelblue', name: 'name1' },
+        { id: 2, collectionId: '1+2', color: 'maroon', name: 'name2' },
+      ]}
+      collections={[{ id: '1+2', color: 'red', yDomain: [-1, 2] }]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>,
+  ])
+  .add('Properties overridden', () => [
+    <DataProvider
+      key="drawPoints"
+      baseDomain={staticBaseDomain}
+      defaultLoader={staticLoader}
+      xAccessor={d => d.timestamp}
+      yAccessor={d => d.value}
+      series={[
+        { id: 1, collectionId: '1+2', color: 'steelblue', name: 'name1' },
+        {
+          id: 2,
+          collectionId: '1+2',
+          color: 'maroon',
+          name: 'name2',
+          drawPoints: false,
+        },
+      ]}
+      collections={[{ id: '1+2', color: 'red', drawPoints: true }]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>,
+    <DataProvider
+      key="strokeWidth"
+      baseDomain={staticBaseDomain}
+      defaultLoader={staticLoader}
+      xAccessor={d => d.timestamp}
+      yAccessor={d => d.value}
+      series={[
+        { id: 1, collectionId: '1+2', color: 'steelblue', name: 'name1' },
+        {
+          id: 2,
+          collectionId: '1+2',
+          color: 'maroon',
+          name: 'name2',
+          strokeWidth: 1,
+        },
+      ]}
+      collections={[{ id: '1+2', color: 'red', strokeWidth: 3 }]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>,
+    <DataProvider
+      key="yAxisDisplayMode"
+      baseDomain={staticBaseDomain}
+      defaultLoader={staticLoader}
+      xAccessor={d => d.timestamp}
+      yAccessor={d => d.value}
+      series={[
+        { id: 1, collectionId: '1+2', color: 'steelblue', name: 'name1' },
+        {
+          id: 2,
+          collectionId: '1+2',
+          color: 'maroon',
+          name: 'name2',
+          // This override should be ignored
+          yAxisDisplayMode: AxisDisplayMode.ALL,
+        },
+      ]}
+      collections={[
+        { id: '1+2', color: 'red', yAxisDisplayMode: AxisDisplayMode.NONE },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>,
+    <DataProvider
+      key="yAxisDisplayMode"
+      baseDomain={staticBaseDomain}
+      defaultLoader={staticLoader}
+      xAccessor={d => d.timestamp}
+      yAccessor={d => d.value}
+      series={[
+        { id: 1, collectionId: '1+2', color: 'steelblue', name: 'name1' },
+        {
+          id: 2,
+          collectionId: '1+2',
+          color: 'maroon',
+          name: 'name2',
+          yDomain: [0.5, 1],
+        },
+      ]}
+      collections={[{ id: '1+2', color: 'red', yDomain: [0, 1] }]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>,
+  ]);


### PR DESCRIPTION
Series may now be grouped into collections, which are passed into the
DataProvider by the new `collections` property. Series which declare
that they are a member of a given collection (by their `collectionId`
property) are not rendered as an individual axis, and are instead folded
into a unified axis with combined zoom & translation capabilities.