### PR TITLE
Support configurable axis placements

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -12,8 +12,17 @@ function loadStories() {
 setDefaults({ inline: true, header: false });
 
 addDecorator((story, context) => (
-  <div style={{ marginLeft: 'auto', marginRight: 'auto', width: '80%' }}>
-    {withInfo()(story)(context)}
+  <div style={{ backgroundColor: '#f3f3f3' }}>
+    <div
+      style={{
+        backgroundColor: '#fff',
+        marginLeft: 'auto',
+        marginRight: 'auto',
+        width: '80%',
+      }}
+    >
+      {withInfo()(story)(context)}
+    </div>
   </div>
 ));
 

--- a/src/components/AxisCollection/YAxis.js
+++ b/src/components/AxisCollection/YAxis.js
@@ -3,7 +3,8 @@ import * as d3 from 'd3';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash.isequal';
 import { createYScale } from '../../utils/scale-helpers';
-import { singleSeriePropType } from '../../utils/proptypes';
+import { singleSeriePropType, axisPlacementType } from '../../utils/proptypes';
+import AxisPlacement from '../LineChart/AxisPlacement';
 
 const propTypes = {
   zoomable: PropTypes.bool,
@@ -19,6 +20,7 @@ const propTypes = {
   }),
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
+  yAxisPlacement: axisPlacementType,
 };
 
 const defaultProps = {
@@ -27,6 +29,7 @@ const defaultProps = {
   yTransformation: null,
   onMouseEnter: null,
   onMouseLeave: null,
+  yAxisPlacement: AxisPlacement.RIGHT,
 };
 
 export default class YAxis extends Component {
@@ -49,6 +52,100 @@ export default class YAxis extends Component {
       }
     }
   }
+
+  getLineProps = ({ tickSizeInner, strokeWidth }) => {
+    const { width, yAxisPlacement } = this.props;
+    switch (yAxisPlacement) {
+      case AxisPlacement.LEFT:
+        return {
+          x1: width - strokeWidth,
+          x2: width - strokeWidth - tickSizeInner,
+          y1: strokeWidth / 2,
+          y2: strokeWidth / 2,
+        };
+      case AxisPlacement.BOTH:
+        throw new Error(
+          'BOTH is not a valid option for YAxis -- please specify RIGHT or LEFT'
+        );
+      case AxisPlacement.RIGHT:
+      case AxisPlacement.UNSPECIFIED:
+      default:
+        return {
+          x1: 0,
+          x2: tickSizeInner,
+          y1: strokeWidth / 2,
+          y2: strokeWidth / 2,
+        };
+    }
+  };
+
+  getPathString = ({ tickSizeOuter, range, strokeWidth }) => {
+    const { yAxisPlacement, width } = this.props;
+    switch (yAxisPlacement) {
+      case AxisPlacement.LEFT:
+        return [
+          `M${width - tickSizeOuter},${range[0] - strokeWidth}`,
+          `H${width - strokeWidth}`,
+          `V${range[1]}`,
+          `H${width - tickSizeOuter}`,
+        ].join('');
+      case AxisPlacement.BOTH:
+        throw new Error(
+          'BOTH is not a valid option for YAxis -- please specify RIGHT or LEFT'
+        );
+      case AxisPlacement.RIGHT:
+      case AxisPlacement.UNSPECIFIED:
+      default:
+        return [
+          // Move to this (x,y); start drawing
+          `M${tickSizeOuter},${range[0] - strokeWidth}`,
+          // Draw a horizontal line half strokeWidth long
+          `H${strokeWidth / 2}`,
+          // Draw a vertical line from bottom to top
+          `V${range[1]}`,
+          // Finish with another horizontal line
+          `H${tickSizeOuter}`,
+        ].join('');
+    }
+  };
+
+  getTextAnchor = () => {
+    const { yAxisPlacement } = this.props;
+    switch (yAxisPlacement) {
+      case AxisPlacement.LEFT:
+        return 'end';
+      case AxisPlacement.BOTH:
+        throw new Error(
+          'BOTH is not a valid option for YAxis -- please specify RIGHT or LEFT'
+        );
+      case AxisPlacement.RIGHT:
+      case AxisPlacement.UNSPECIFIED:
+      default:
+        return 'start';
+    }
+  };
+
+  getTextProps = ({ tickSizeInner, tickPadding, strokeWidth }) => {
+    const { width, yAxisPlacement } = this.props;
+    switch (yAxisPlacement) {
+      case AxisPlacement.LEFT:
+        return {
+          x: Math.max(width - tickSizeInner, 0) - tickPadding,
+          y: strokeWidth / 2,
+        };
+      case AxisPlacement.BOTH:
+        throw new Error(
+          'BOTH is not a valid option for YAxis -- please specify RIGHT or LEFT'
+        );
+      case AxisPlacement.RIGHT:
+      case AxisPlacement.UNSPECIFIED:
+      default:
+        return {
+          x: Math.max(tickSizeInner, 0) + tickPadding,
+          y: strokeWidth / 2,
+        };
+    }
+  };
 
   syncZoomingState = () => {
     if (this.props.zoomable) {
@@ -95,37 +192,31 @@ export default class YAxis extends Component {
     // same as for xAxis but consider height of the screen ~two times smaller
     const nTicks = Math.floor(height / 50) || 1;
     const values = scale.ticks(nTicks);
-    const k = 1;
     const tickFormat = scale.tickFormat(nTicks);
     const range = scale.range().map(r => r + halfStrokeWidth);
-    const pathString = [
-      // Move to this (x,y); start drawing
-      `M${k * tickSizeOuter},${range[0] - strokeWidth}`,
-      // Draw a horizontal line halfStrokeWidth long
-      `H${halfStrokeWidth}`,
-      // Draw a vertical line from bottom to top
-      `V${range[1]}`,
-      // Finish with another horizontal line
-      `H${k * tickSizeOuter}`,
-    ].join('');
     return (
       <g
         className="axis"
         fill="none"
         fontSize={tickFontSize}
-        textAnchor="start"
+        textAnchor={this.getTextAnchor()}
         strokeWidth={strokeWidth}
       >
-        <path stroke={series.color} d={pathString} />
+        <path
+          stroke={series.color}
+          d={this.getPathString({ tickSizeOuter, range, strokeWidth })}
+        />
         {values.map(v => {
-          const lineProps = { stroke: series.color };
-          lineProps.x2 = k * tickSizeInner;
-          lineProps.y1 = halfStrokeWidth;
-          lineProps.y2 = halfStrokeWidth;
+          const lineProps = {
+            stroke: series.color,
+            ...this.getLineProps({ tickSizeInner, strokeWidth }),
+          };
 
-          const textProps = { fill: series.color, dy: '0.32em' };
-          textProps.x = k * Math.max(tickSizeInner, 0) + tickPadding;
-          textProps.y = halfStrokeWidth;
+          const textProps = {
+            fill: series.color,
+            dy: '0.32em',
+            ...this.getTextProps({ tickSizeInner, tickPadding, strokeWidth }),
+          };
           return (
             <g key={+v} opacity={1} transform={`translate(0, ${scale(v)})`}>
               <line {...lineProps} />

--- a/src/components/AxisCollection/index.js
+++ b/src/components/AxisCollection/index.js
@@ -163,6 +163,7 @@ class AxisCollection extends React.Component {
               yTransformation={yTransformations[c.id]}
               onMouseEnter={this.onAxisMouseEnter(c.id)}
               onMouseLeave={this.onAxisMouseLeave(c.id)}
+              yAxisPlacement={yAxisPlacement}
             />
           );
         })
@@ -192,13 +193,16 @@ class AxisCollection extends React.Component {
   };
 
   render() {
-    const { height, series, yAxisWidth } = this.props;
+    const { collections, height, series, yAxisWidth } = this.props;
 
-    const calculatedWidth = series
+    const calculatedWidth = []
+      .concat(series)
+      .concat(collections)
+      .filter(item => item.collectionId === undefined)
       .filter(this.axisFilter(AxisDisplayMode.ALL))
       .filter(this.placementFilter)
-      .reduce((acc, s) => {
-        if (s.yAxisDisplayMode === AxisDisplayMode.COLLAPSED) {
+      .reduce((acc, item) => {
+        if (item.yAxisDisplayMode === AxisDisplayMode.COLLAPSED) {
           return acc;
         }
         return acc + yAxisWidth;

--- a/src/components/LineChart/AxisDisplayMode.js
+++ b/src/components/LineChart/AxisDisplayMode.js
@@ -1,9 +1,14 @@
 const AxisDisplayMode = {
-  ALL: { id: 'ALL', width: (axisWidth, numAxes) => +axisWidth * +numAxes },
-  NONE: { id: 'NONE', width: () => 0 },
+  ALL: {
+    id: 'ALL',
+    width: (axisWidth, numAxes) => +axisWidth * +numAxes,
+    toString: () => 'ALL',
+  },
+  NONE: { id: 'NONE', width: () => 0, toString: () => 'NONE' },
   COLLAPSED: {
     id: 'COLLAPSED',
     width: (axisWidth, numAxes = 0) => Math.min(+numAxes, 1) * +axisWidth,
+    toString: () => 'COLLAPSED',
   },
 };
 

--- a/src/components/LineChart/AxisPlacement.js
+++ b/src/components/LineChart/AxisPlacement.js
@@ -1,0 +1,8 @@
+const AxisPlacement = {
+  UNSPECIFIED: { id: 0, name: 'UNSPECIFIED' },
+  RIGHT: { id: 1, name: 'RIGHT' },
+  LEFT: { id: 2, name: 'LEFT' },
+  BOTH: { id: 3, name: 'BOTH' },
+};
+
+export default AxisPlacement;

--- a/src/components/LineChart/AxisPlacement.js
+++ b/src/components/LineChart/AxisPlacement.js
@@ -1,8 +1,8 @@
 const AxisPlacement = {
-  UNSPECIFIED: { id: 0, name: 'UNSPECIFIED' },
-  RIGHT: { id: 1, name: 'RIGHT' },
-  LEFT: { id: 2, name: 'LEFT' },
-  BOTH: { id: 3, name: 'BOTH' },
+  UNSPECIFIED: { id: 0, name: 'UNSPECIFIED', toString: () => 'UNSPECIFIED' },
+  RIGHT: { id: 1, name: 'RIGHT', toString: () => 'RIGHT' },
+  LEFT: { id: 2, name: 'LEFT', toString: () => 'LEFT' },
+  BOTH: { id: 3, name: 'BOTH', toString: () => 'BOTH' },
 };
 
 export default AxisPlacement;

--- a/src/components/LineChart/Layout.js
+++ b/src/components/LineChart/Layout.js
@@ -34,13 +34,29 @@ const Layout = ({ contextChart, lineChart, xAxis, yAxis, yAxisPlacement }) => {
   const yAxes = [];
   let areas;
 
+  const quote = s => `'${s}'`;
+
   switch (yAxisPlacement) {
     case AxisPlacement.LEFT:
-      areas = "'yaxis chart' '. xaxis' '. context'";
+      areas = [
+        // formatting for readability
+        'yaxis chart',
+        '. xaxis',
+        '. context',
+      ]
+        .map(quote)
+        .join(' ');
       yAxes.push(axisContainer('yaxis')(yAxis, yAxisPlacement));
       break;
     case AxisPlacement.BOTH: {
-      areas = "'yaxis-left chart yaxis-right' '. xaxis .' '. context .'";
+      areas = [
+        // formatting for readability
+        'yaxis-left chart yaxis-right',
+        '. xaxis .',
+        '. context .',
+      ]
+        .map(quote)
+        .join(' ');
       yAxes.push(axisContainer('yaxis-left')(yAxis, AxisPlacement.LEFT));
       yAxes.push(axisContainer('yaxis-right')(yAxis, AxisPlacement.RIGHT));
       break;
@@ -48,7 +64,14 @@ const Layout = ({ contextChart, lineChart, xAxis, yAxis, yAxisPlacement }) => {
     case AxisPlacement.RIGHT:
     case AxisPlacement.UNSPECIFIED:
     default:
-      areas = "'chart yaxis' 'xaxis .' 'context .'";
+      areas = [
+        // formatting for readability
+        'chart yaxis',
+        'xaxis .',
+        'context .',
+      ]
+        .map(quote)
+        .join(' ');
       yAxes.push(axisContainer('yaxis')(yAxis, yAxisPlacement));
       break;
   }

--- a/src/components/LineChart/Layout.js
+++ b/src/components/LineChart/Layout.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import AxisPlacement from './AxisPlacement';
+import { axisPlacementType } from '../../utils/proptypes';
+
+const propTypes = {
+  contextChart: PropTypes.node,
+  lineChart: PropTypes.node.isRequired,
+  xAxis: PropTypes.node.isRequired,
+  yAxis: PropTypes.node.isRequired,
+  yAxisPlacement: axisPlacementType,
+};
+
+const defaultProps = {
+  yAxisPlacement: AxisPlacement.RIGHT,
+  contextChart: null,
+};
+
+const axisContainer = area => (axis, placement) => (
+  <div
+    key={area}
+    className="y-axis-container"
+    style={{
+      gridArea: area,
+      display: 'flex',
+      flexDirection: 'column',
+    }}
+  >
+    {React.cloneElement(axis, { yAxisPlacement: placement })}
+  </div>
+);
+
+const Layout = ({ contextChart, lineChart, xAxis, yAxis, yAxisPlacement }) => {
+  const yAxes = [];
+  let areas;
+
+  switch (yAxisPlacement) {
+    case AxisPlacement.LEFT:
+      areas = "'yaxis chart' '. xaxis' '. context'";
+      yAxes.push(axisContainer('yaxis')(yAxis, yAxisPlacement));
+      break;
+    case AxisPlacement.BOTH: {
+      areas = "'yaxis-left chart yaxis-right' '. xaxis .' '. context .'";
+      yAxes.push(axisContainer('yaxis-left')(yAxis, AxisPlacement.LEFT));
+      yAxes.push(axisContainer('yaxis-right')(yAxis, AxisPlacement.RIGHT));
+      break;
+    }
+    case AxisPlacement.RIGHT:
+    case AxisPlacement.UNSPECIFIED:
+    default:
+      areas = "'chart yaxis' 'xaxis .' 'context .'";
+      yAxes.push(axisContainer('yaxis')(yAxis, yAxisPlacement));
+      break;
+  }
+  return (
+    <div
+      className="linechart-container"
+      style={{
+        display: 'grid',
+        gridTemplateAreas: areas,
+        height: '100%',
+      }}
+    >
+      <div
+        className="lines-container"
+        style={{ gridArea: 'chart', height: '100%' }}
+      >
+        {lineChart}
+      </div>
+
+      {yAxes}
+
+      <div
+        className="x-axis-container"
+        style={{ gridArea: 'xaxis', width: '100%' }}
+      >
+        {xAxis}
+      </div>
+      <div style={{ gridArea: 'spacer' }} />
+      {contextChart && (
+        <div
+          className="context-container"
+          style={{
+            gridArea: 'context',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          {contextChart}
+        </div>
+      )}
+    </div>
+  );
+};
+
+Layout.propTypes = propTypes;
+Layout.defaultProps = defaultProps;
+
+export default Layout;

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -160,15 +160,13 @@ class LineChartComponent extends Component {
     const yAxisPlacements = []
       .concat(series.filter(s => s.collectionId === undefined))
       .concat(collections)
-      .reduce(
-        (acc, item) => {
-          if (item.yAxisPlacement) {
-            acc[item.yAxisPlacement] = (acc[item.yAxisPlacement] || 0) + 1;
-          }
-          return acc;
-        },
-        { [yAxisPlacement]: 1 }
-      );
+      .reduce((acc, item) => {
+        const placement = item.yAxisPlacement || yAxisPlacement;
+        if (placement) {
+          acc[placement] = (acc[placement] || 0) + 1;
+        }
+        return acc;
+      }, {});
     if (yAxisPlacements[AxisPlacement.BOTH]) {
       return AxisPlacement.BOTH;
     }

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -144,22 +144,22 @@ class LineChartComponent extends Component {
     const yAxisPlacements = series.reduce(
       (acc, s) => {
         if (s.yAxisPlacement) {
-          acc[s.yAxisPlacement.id] = (acc[s.yAxisPlacement.id] || 0) + 1;
+          acc[s.yAxisPlacement] = (acc[s.yAxisPlacement] || 0) + 1;
         }
         return acc;
       },
-      { [yAxisPlacement.id]: 1 }
+      { [yAxisPlacement]: 1 }
     );
-    if (yAxisPlacements[AxisPlacement.BOTH.id]) {
+    if (yAxisPlacements[AxisPlacement.BOTH]) {
       return AxisPlacement.BOTH;
     }
     if (
-      yAxisPlacements[AxisPlacement.LEFT.id] &&
-      yAxisPlacements[AxisPlacement.RIGHT.id]
+      yAxisPlacements[AxisPlacement.LEFT] &&
+      yAxisPlacements[AxisPlacement.RIGHT]
     ) {
       return AxisPlacement.BOTH;
     }
-    if (yAxisPlacements[AxisPlacement.LEFT.id]) {
+    if (yAxisPlacements[AxisPlacement.LEFT]) {
       return AxisPlacement.LEFT;
     }
     return yAxisPlacement || AxisPlacement.RIGHT;

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -133,7 +133,6 @@ class LineChartComponent extends Component {
       .concat(collections)
       .filter(item => !item.hidden)
       .filter(item => item.collectionId === undefined)
-      .filter(displayModeFilter(AxisDisplayMode.ALL))
       .filter(
         item =>
           (item.yAxisPlacement || yAxisPlacement) &&
@@ -145,19 +144,21 @@ class LineChartComponent extends Component {
       filteredItems.filter(displayModeFilter(AxisDisplayMode.COLLAPSED))
         .length > 0;
 
-    return filteredItems.reduce((acc, item) => {
-      // COLLAPSED items are already accounted-for with the initial value.
-      if (item.yAxisDisplayMode === AxisDisplayMode.COLLAPSED) {
-        return acc;
-      }
-      return acc + yAxisWidth;
-    }, hasCollapsed ? yAxisWidth : 0);
+    return filteredItems
+      .filter(displayModeFilter(AxisDisplayMode.ALL))
+      .reduce((acc, item) => {
+        // COLLAPSED items are already accounted-for with the initial value.
+        if (item.yAxisDisplayMode === AxisDisplayMode.COLLAPSED) {
+          return acc;
+        }
+        return acc + yAxisWidth;
+      }, hasCollapsed ? yAxisWidth : 0);
   };
 
   getYAxisPlacement = () => {
     const { collections, series, yAxisPlacement } = this.props;
     const yAxisPlacements = []
-      .concat(series)
+      .concat(series.filter(s => s.collectionId === undefined))
       .concat(collections)
       .reduce(
         (acc, item) => {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ export { default as LineChart } from './components/LineChart';
 export {
   default as AxisDisplayMode,
 } from './components/LineChart/AxisDisplayMode';
+export { default as AxisPlacement } from './components/LineChart/AxisPlacement';
 export { default as Line } from './components/Line';
 export { default as XAxis } from './components/XAxis';
 export { default as Brush } from './components/Brush';

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -61,6 +61,11 @@ export const axisDisplayModeType = PropTypes.shape({
   width: PropTypes.func.isRequired,
 });
 
+export const axisPlacementType = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+});
+
 export const coordinatePropType = PropTypes.shape({
   xpos: PropTypes.number.isRequired,
   ypos: PropTypes.number.isRequired,

--- a/stories/YAxisPlacements.stories.js
+++ b/stories/YAxisPlacements.stories.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import 'react-select/dist/react-select.css';
 import { storiesOf } from '@storybook/react';
-import { DataProvider, LineChart, AxisPlacement } from '../src';
+import {
+  DataProvider,
+  LineChart,
+  AxisPlacement,
+  AxisDisplayMode,
+} from '../src';
 import { staticLoader } from './loaders';
 
 const staticBaseDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
@@ -92,5 +97,38 @@ storiesOf('Y-Axis Placement', module)
       ]}
     >
       <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.RIGHT} />
+    </DataProvider>
+  ))
+  .add('Collapsed axis', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        {
+          id: 1,
+          color: 'steelblue',
+          yAxisDisplayMode: AxisDisplayMode.COLLAPSED,
+        },
+        { id: 2, color: 'maroon', yAxisDisplayMode: AxisDisplayMode.COLLAPSED },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.BOTH} />
+    </DataProvider>
+  ))
+  .add('Mixed axis modes', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        {
+          id: 1,
+          color: 'steelblue',
+          yAxisDisplayMode: AxisDisplayMode.COLLAPSED,
+        },
+        { id: 2, color: 'maroon', yAxisDisplayMode: AxisDisplayMode.COLLAPSED },
+        { id: 2, color: 'orange', yAxisDisplayMode: AxisDisplayMode.ALL },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.BOTH} />
     </DataProvider>
   ));

--- a/stories/YAxisPlacements.stories.js
+++ b/stories/YAxisPlacements.stories.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import 'react-select/dist/react-select.css';
+import { storiesOf } from '@storybook/react';
+import { DataProvider, LineChart, AxisPlacement } from '../src';
+import { staticLoader } from './loaders';
+
+const staticBaseDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
+const CHART_HEIGHT = 500;
+
+storiesOf('Y-Axis Placement', module)
+  .add('Unspecified', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>
+  ))
+  .add('Left', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.LEFT} />
+    </DataProvider>
+  ))
+  .add('Right', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.RIGHT} />
+    </DataProvider>
+  ))
+  .add('Both', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.BOTH} />
+    </DataProvider>
+  ))
+  .add('Split series', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        { id: 1, color: 'steelblue', yAxisPlacement: AxisPlacement.LEFT },
+        { id: 2, color: 'maroon', yAxisPlacement: AxisPlacement.RIGHT },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>
+  ))
+  .add('Split series, with BOTH', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        { id: 1, color: 'steelblue', yAxisPlacement: AxisPlacement.LEFT },
+        { id: 2, color: 'maroon', yAxisPlacement: AxisPlacement.RIGHT },
+        { id: 3, color: 'orange', yAxisPlacement: AxisPlacement.BOTH },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>
+  ))
+  .add('Split series, overriding chart', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        { id: 1, color: 'steelblue', yAxisPlacement: AxisPlacement.LEFT },
+        { id: 2, color: 'maroon', yAxisPlacement: AxisPlacement.RIGHT },
+        { id: 3, color: 'orange', yAxisPlacement: AxisPlacement.BOTH },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.LEFT} />
+    </DataProvider>
+  ))
+  .add('All on the wrong side', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        { id: 1, color: 'steelblue', yAxisPlacement: AxisPlacement.LEFT },
+        { id: 2, color: 'maroon', yAxisPlacement: AxisPlacement.LEFT },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.RIGHT} />
+    </DataProvider>
+  ));

--- a/stories/YAxisPlacements.stories.js
+++ b/stories/YAxisPlacements.stories.js
@@ -13,44 +13,97 @@ const staticBaseDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
 const CHART_HEIGHT = 500;
 
 storiesOf('Y-Axis Placement', module)
-  .add('Unspecified', () => (
+  .add('Unspecified', () => [
     <DataProvider
+      key="series"
       defaultLoader={staticLoader}
       baseDomain={staticBaseDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} />
-    </DataProvider>
-  ))
-  .add('Left', () => (
+    </DataProvider>,
     <DataProvider
+      key="collections"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        { id: 1, color: 'steelblue', collectionId: '1+2' },
+        { id: 2, color: 'maroon', collectionId: '1+2' },
+      ]}
+      collections={[{ id: '1+2', color: 'red' }]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>,
+  ])
+  .add('Left', () => [
+    <DataProvider
+      key="series"
       defaultLoader={staticLoader}
       baseDomain={staticBaseDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.LEFT} />
-    </DataProvider>
-  ))
-  .add('Right', () => (
+    </DataProvider>,
     <DataProvider
+      key="collections"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        { id: 1, color: 'steelblue', collectionId: '1+2' },
+        { id: 2, color: 'maroon', collectionId: '1+2' },
+      ]}
+      collections={[{ id: '1+2', color: 'red' }]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.LEFT} />
+    </DataProvider>,
+  ])
+  .add('Right', () => [
+    <DataProvider
+      key="series"
       defaultLoader={staticLoader}
       baseDomain={staticBaseDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.RIGHT} />
-    </DataProvider>
-  ))
-  .add('Both', () => (
+    </DataProvider>,
     <DataProvider
+      key="collections"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        { id: 1, color: 'steelblue', collectionId: '1+2' },
+        { id: 2, color: 'maroon', collectionId: '1+2' },
+      ]}
+      collections={[{ id: '1+2', color: 'red' }]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.RIGHT} />
+    </DataProvider>,
+  ])
+  .add('Both', () => [
+    <DataProvider
+      key="series"
       defaultLoader={staticLoader}
       baseDomain={staticBaseDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.BOTH} />
-    </DataProvider>
-  ))
-  .add('Split series', () => (
+    </DataProvider>,
     <DataProvider
+      key="collections"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        { id: 1, color: 'steelblue', collectionId: '1+2' },
+        { id: 2, color: 'maroon', collectionId: '1+2' },
+      ]}
+      collections={[{ id: '1+2', color: 'red' }]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.BOTH} />
+    </DataProvider>,
+  ])
+  .add('Split', () => [
+    <DataProvider
+      key="series"
       defaultLoader={staticLoader}
       baseDomain={staticBaseDomain}
       series={[
@@ -59,10 +112,36 @@ storiesOf('Y-Axis Placement', module)
       ]}
     >
       <LineChart height={CHART_HEIGHT} />
-    </DataProvider>
-  ))
-  .add('Split series, with BOTH', () => (
+    </DataProvider>,
     <DataProvider
+      key="collections"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        {
+          id: 1,
+          color: 'steelblue',
+          collectionId: '1',
+          yAxisPlacement: AxisPlacement.LEFT,
+        },
+        {
+          id: 2,
+          color: 'maroon',
+          collectionId: '2',
+          yAxisPlacement: AxisPlacement.RIGHT,
+        },
+      ]}
+      collections={[
+        { id: '1', color: 'red', yAxisPlacement: AxisPlacement.LEFT },
+        { id: '2', color: 'blue', yAxisPlacement: AxisPlacement.RIGHT },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>,
+  ])
+  .add('Split, with BOTH', () => [
+    <DataProvider
+      key="series"
       defaultLoader={staticLoader}
       baseDomain={staticBaseDomain}
       series={[
@@ -72,10 +151,43 @@ storiesOf('Y-Axis Placement', module)
       ]}
     >
       <LineChart height={CHART_HEIGHT} />
-    </DataProvider>
-  ))
-  .add('Split series, overriding chart', () => (
+    </DataProvider>,
     <DataProvider
+      key="collections"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        {
+          id: 1,
+          color: 'steelblue',
+          collectionId: '1',
+          yAxisPlacement: AxisPlacement.LEFT,
+        },
+        {
+          id: 2,
+          color: 'maroon',
+          collectionId: '2',
+          yAxisPlacement: AxisPlacement.RIGHT,
+        },
+        {
+          id: 3,
+          color: 'orange',
+          collectionId: '3',
+          yAxisPlacement: AxisPlacement.BOTH,
+        },
+      ]}
+      collections={[
+        { id: '1', color: 'red', yAxisPlacement: AxisPlacement.LEFT },
+        { id: '2', color: 'blue', yAxisPlacement: AxisPlacement.RIGHT },
+        { id: '3', color: 'green', yAxisPlacement: AxisPlacement.BOTH },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} />
+    </DataProvider>,
+  ])
+  .add('Split, overriding chart', () => [
+    <DataProvider
+      key="series"
       defaultLoader={staticLoader}
       baseDomain={staticBaseDomain}
       series={[
@@ -85,10 +197,43 @@ storiesOf('Y-Axis Placement', module)
       ]}
     >
       <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.LEFT} />
-    </DataProvider>
-  ))
-  .add('All on the wrong side', () => (
+    </DataProvider>,
     <DataProvider
+      key="collections"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        {
+          id: 1,
+          color: 'steelblue',
+          collectionId: '1',
+          yAxisPlacement: AxisPlacement.LEFT,
+        },
+        {
+          id: 2,
+          color: 'maroon',
+          collectionId: '2',
+          yAxisPlacement: AxisPlacement.RIGHT,
+        },
+        {
+          id: 3,
+          color: 'orange',
+          collectionId: '3',
+          yAxisPlacement: AxisPlacement.BOTH,
+        },
+      ]}
+      collections={[
+        { id: '1', color: 'red', yAxisPlacement: AxisPlacement.LEFT },
+        { id: '2', color: 'blue', yAxisPlacement: AxisPlacement.RIGHT },
+        { id: '3', color: 'green', yAxisPlacement: AxisPlacement.BOTH },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.LEFT} />
+    </DataProvider>,
+  ])
+  .add('All on the wrong side', () => [
+    <DataProvider
+      key="series"
       defaultLoader={staticLoader}
       baseDomain={staticBaseDomain}
       series={[
@@ -97,10 +242,33 @@ storiesOf('Y-Axis Placement', module)
       ]}
     >
       <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.RIGHT} />
-    </DataProvider>
-  ))
-  .add('Collapsed axis', () => (
+    </DataProvider>,
     <DataProvider
+      key="collections"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        {
+          id: 1,
+          color: 'steelblue',
+          collectionId: '1+2',
+        },
+        {
+          id: 2,
+          color: 'maroon',
+          collectionId: '1+2',
+        },
+      ]}
+      collections={[
+        { id: '1+2', color: 'red', yAxisPlacement: AxisPlacement.LEFT },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.RIGHT} />
+    </DataProvider>,
+  ])
+  .add('Collapsed axis', () => [
+    <DataProvider
+      key="series"
       defaultLoader={staticLoader}
       baseDomain={staticBaseDomain}
       series={[
@@ -113,10 +281,37 @@ storiesOf('Y-Axis Placement', module)
       ]}
     >
       <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.BOTH} />
-    </DataProvider>
-  ))
-  .add('Mixed axis modes', () => (
+    </DataProvider>,
     <DataProvider
+      key="collections"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        {
+          id: 1,
+          color: 'steelblue',
+          collectionId: '1+2',
+        },
+        {
+          id: 2,
+          color: 'maroon',
+          collectionId: '1+2',
+        },
+      ]}
+      collections={[
+        {
+          id: '1+2',
+          color: 'red',
+          yAxisDisplayMode: AxisDisplayMode.COLLAPSED,
+        },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.BOTH} />
+    </DataProvider>,
+  ])
+  .add('Mixed axis modes', () => [
+    <DataProvider
+      key="series"
       defaultLoader={staticLoader}
       baseDomain={staticBaseDomain}
       series={[
@@ -130,5 +325,32 @@ storiesOf('Y-Axis Placement', module)
       ]}
     >
       <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.BOTH} />
-    </DataProvider>
-  ));
+    </DataProvider>,
+    <DataProvider
+      key="collections"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        {
+          id: 1,
+          color: 'steelblue',
+          yAxisDisplayMode: AxisDisplayMode.COLLAPSED,
+        },
+        {
+          id: 2,
+          color: 'maroon',
+          collectionId: '1+2',
+          yAxisDisplayMode: AxisDisplayMode.COLLAPSED,
+        },
+        {
+          id: 2,
+          color: 'orange',
+          collectionId: '1+2',
+          yAxisDisplayMode: AxisDisplayMode.ALL,
+        },
+      ]}
+      collections={[{ id: '1+2', color: 'red' }]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.BOTH} />
+    </DataProvider>,
+  ]);

--- a/stories/YAxisPlacements.stories.js
+++ b/stories/YAxisPlacements.stories.js
@@ -266,6 +266,19 @@ storiesOf('Y-Axis Placement', module)
       <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.RIGHT} />
     </DataProvider>,
   ])
+  .add('Misleading placements', () => [
+    <DataProvider
+      key="series"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[
+        { id: 1, color: 'steelblue', yAxisPlacement: AxisPlacement.LEFT },
+        { id: 2, color: 'maroon' },
+      ]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.RIGHT} />
+    </DataProvider>,
+  ])
   .add('Collapsed axis', () => [
     <DataProvider
       key="series"


### PR DESCRIPTION
Add a new `yAxisPlacement` property to both LineChart and series. This
value is one of the defined `AxisPlacement` constants, and it controls
where the respective axes/axis live/s.

It has the following behaviors:
  - UNSPECIFIED
     - Same as not using the property, and the default value (RIGHT) is used.
-  RIGHT
    - Default behavior -- the y-axes are rendered to the right of the line chart.
-  LEFT
    - Axes are rendered to the left of the line chart; series are mirrored so that the proximity to the chart is preserved.
-  BOTH
    - Axes are rendered on both sides of the chart. These are kept in sync with each other.

If the series objects specify this option, then they will be placed as
specified, overriding the chart's value if necessary.

Fixes #89