### PR TITLE
Add support for grid lines

### DIFF
--- a/src/components/GridLines/index.js
+++ b/src/components/GridLines/index.js
@@ -8,33 +8,22 @@ const propTypes = {
   grid: gridPropType,
   height: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,
-  opacity: PropTypes.number,
-  color: PropTypes.string,
-  strokeWidth: PropTypes.number,
   series: seriesPropType.isRequired,
   subDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
 };
 
 const defaultProps = {
   grid: null,
-  opacity: 0.4,
-  color: '#000',
-  strokeWidth: 1,
 };
+
+const DEFAULT_COLOR = '#666';
+const DEFAULT_OPACITY = 0.6;
+const DEFAULT_STROKE_WIDTH = 1;
 
 class GridLines extends React.Component {
   state = {};
   render() {
-    const {
-      color,
-      grid,
-      height,
-      width,
-      opacity,
-      series,
-      subDomain,
-      strokeWidth,
-    } = this.props;
+    const { grid, height, width, series, subDomain } = this.props;
 
     if (!grid) {
       return null;
@@ -63,15 +52,25 @@ class GridLines extends React.Component {
             lines.push(
               <line
                 key={`horizontal-${s.id}-${v}`}
-                opacity={y.opacity || grid.opacity || opacity}
+                opacity={y.opacity || grid.opacity || DEFAULT_OPACITY}
                 stroke={
-                  y.color === null ? s.color : y.color || grid.color || color
+                  y.color === null
+                    ? s.color
+                    : y.color || grid.color || DEFAULT_COLOR
                 }
-                strokeWidth={y.strokeWidth || grid.strokeWidth || strokeWidth}
+                strokeWidth={
+                  y.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH
+                }
                 x1={0}
                 x2={width}
-                y1={(y.strokeWidth || strokeWidth) / 2}
-                y2={(y.strokeWidth || strokeWidth) / 2}
+                y1={
+                  (y.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH) /
+                  2
+                }
+                y2={
+                  (y.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH) /
+                  2
+                }
                 transform={`translate(0, ${scale(v)})`}
               />
             );
@@ -90,9 +89,11 @@ class GridLines extends React.Component {
               x2={width}
               y1={position}
               y2={position}
-              stroke={y.color || color}
-              strokeWidth={y.strokeWidth || strokeWidth}
-              opacity={y.opacity || opacity}
+              stroke={y.color || grid.color || DEFAULT_COLOR}
+              strokeWidth={
+                y.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH
+              }
+              opacity={y.opacity || grid.opacity || DEFAULT_OPACITY}
             />
           );
         }
@@ -110,9 +111,11 @@ class GridLines extends React.Component {
               x2={width}
               y1={position}
               y2={position}
-              stroke={y.color || color}
-              strokeWidth={y.strokeWidth || strokeWidth}
-              opacity={y.opacity || opacity}
+              stroke={y.color || grid.color || DEFAULT_COLOR}
+              strokeWidth={
+                y.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH
+              }
+              opacity={y.opacity || grid.opacity || DEFAULT_OPACITY}
             />
           );
         }
@@ -133,9 +136,11 @@ class GridLines extends React.Component {
               y2={height}
               x1={position}
               x2={position}
-              stroke={x.color || color}
-              strokeWidth={x.strokeWidth || strokeWidth}
-              opacity={x.opacity || opacity}
+              stroke={x.color || grid.color || DEFAULT_COLOR}
+              strokeWidth={
+                x.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH
+              }
+              opacity={x.opacity || grid.opacity || DEFAULT_OPACITY}
             />
           );
         }
@@ -147,13 +152,19 @@ class GridLines extends React.Component {
           lines.push(
             <line
               key={`vertical-${+v}`}
-              opacity={x.opacity || grid.opacity || opacity}
-              stroke={x.color || grid.color || color}
-              strokeWidth={x.strokeWidth || grid.strokeWidth || strokeWidth}
+              opacity={x.opacity || grid.opacity || DEFAULT_OPACITY}
+              stroke={x.color || grid.color || DEFAULT_COLOR}
+              strokeWidth={
+                x.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH
+              }
               y1={0}
               y2={height}
-              x1={(x.strokeWidth || grid.strokeWidth || strokeWidth) / 2}
-              x2={(x.strokeWidth || grid.strokeWidth || strokeWidth) / 2}
+              x1={
+                (x.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH) / 2
+              }
+              x2={
+                (x.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH) / 2
+              }
               transform={`translate(${scale(v)}, 0)`}
             />
           );
@@ -172,9 +183,11 @@ class GridLines extends React.Component {
               y2={height}
               x1={position}
               x2={position}
-              stroke={x.color || color}
-              strokeWidth={x.strokeWidth || strokeWidth}
-              opacity={x.opacity || opacity}
+              stroke={x.color || grid.color || DEFAULT_COLOR}
+              strokeWidth={
+                x.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH
+              }
+              opacity={x.opacity || grid.opacity || DEFAULT_OPACITY}
             />
           );
         }

--- a/src/components/GridLines/index.js
+++ b/src/components/GridLines/index.js
@@ -1,0 +1,202 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ScalerContext from '../../context/Scaler';
+import { gridPropType, seriesPropType } from '../../utils/proptypes';
+import { createYScale, createXScale } from '../../utils/scale-helpers';
+
+const propTypes = {
+  grid: gridPropType,
+  height: PropTypes.number.isRequired,
+  width: PropTypes.number.isRequired,
+  opacity: PropTypes.number,
+  color: PropTypes.string,
+  strokeWidth: PropTypes.number,
+  series: seriesPropType.isRequired,
+  subDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+};
+
+const defaultProps = {
+  grid: null,
+  opacity: 0.4,
+  color: '#000',
+  strokeWidth: 1,
+};
+
+class GridLines extends React.Component {
+  state = {};
+  render() {
+    const {
+      color,
+      grid,
+      height,
+      width,
+      opacity,
+      series,
+      subDomain,
+      strokeWidth,
+    } = this.props;
+
+    if (!grid) {
+      return null;
+    }
+
+    const { x, y } = grid;
+    if (!x && !y) {
+      return null;
+    }
+
+    const lines = [];
+
+    if (y) {
+      if (y.seriesIds) {
+        const seriesIdMap = y.seriesIds.reduce(
+          (dict, id) => ({ ...dict, [id]: true }),
+          {}
+        );
+        series.filter(s => seriesIdMap[s.id]).forEach(s => {
+          // This is heavily inspired by YAxis -- maybe we could consolidate?
+          const scale = createYScale(s.yDomain, height);
+          const nTicks = y.count || Math.floor(height / 50) || 1;
+          const values = scale.ticks(nTicks);
+
+          values.forEach(v => {
+            lines.push(
+              <line
+                key={`horizontal-${s.id}-${v}`}
+                opacity={y.opacity || grid.opacity || opacity}
+                stroke={
+                  y.color === null ? s.color : y.color || grid.color || color
+                }
+                strokeWidth={y.strokeWidth || grid.strokeWidth || strokeWidth}
+                x1={0}
+                x2={width}
+                y1={(y.strokeWidth || strokeWidth) / 2}
+                y2={(y.strokeWidth || strokeWidth) / 2}
+                transform={`translate(0, ${scale(v)})`}
+              />
+            );
+          });
+        });
+      } else if (y.pixels) {
+        for (
+          let position = (height % y.pixels) / 2;
+          position <= height;
+          position += y.pixels
+        ) {
+          lines.push(
+            <line
+              key={`horizontal-${position}`}
+              x1={0}
+              x2={width}
+              y1={position}
+              y2={position}
+              stroke={y.color || color}
+              strokeWidth={y.strokeWidth || strokeWidth}
+              opacity={y.opacity || opacity}
+            />
+          );
+        }
+      } else if (y.count) {
+        const interval = height / y.count;
+        for (
+          let position = interval / 2;
+          position <= height;
+          position += interval
+        ) {
+          lines.push(
+            <line
+              key={`horizontal-${position}`}
+              x1={0}
+              x2={width}
+              y1={position}
+              y2={position}
+              stroke={y.color || color}
+              strokeWidth={y.strokeWidth || strokeWidth}
+              opacity={y.opacity || opacity}
+            />
+          );
+        }
+      }
+    }
+
+    if (x) {
+      if (x.pixels) {
+        for (
+          let position = (width % x.pixels) / 2;
+          position <= width;
+          position += x.pixels
+        ) {
+          lines.push(
+            <line
+              key={`vertical-${position}`}
+              y1={0}
+              y2={height}
+              x1={position}
+              x2={position}
+              stroke={x.color || color}
+              strokeWidth={x.strokeWidth || strokeWidth}
+              opacity={x.opacity || opacity}
+            />
+          );
+        }
+      } else if (x.ticks !== undefined) {
+        // This heavily inspired by XAxis -- maybe we can consolidate them?
+        const scale = createXScale(subDomain, width);
+        const values = scale.ticks(x.ticks || Math.floor(width / 100) || 1);
+        values.forEach(v => {
+          lines.push(
+            <line
+              key={`vertical-${+v}`}
+              opacity={x.opacity || grid.opacity || opacity}
+              stroke={x.color || grid.color || color}
+              strokeWidth={x.strokeWidth || grid.strokeWidth || strokeWidth}
+              y1={0}
+              y2={height}
+              x1={(x.strokeWidth || grid.strokeWidth || strokeWidth) / 2}
+              x2={(x.strokeWidth || grid.strokeWidth || strokeWidth) / 2}
+              transform={`translate(${scale(v)}, 0)`}
+            />
+          );
+        });
+      } else if (x.count) {
+        const interval = width / x.count;
+        for (
+          let position = interval / 2;
+          position <= width;
+          position += interval
+        ) {
+          lines.push(
+            <line
+              key={`vertical-${position}`}
+              y1={0}
+              y2={height}
+              x1={position}
+              x2={position}
+              stroke={x.color || color}
+              strokeWidth={x.strokeWidth || strokeWidth}
+              opacity={x.opacity || opacity}
+            />
+          );
+        }
+      }
+    }
+
+    return lines;
+  }
+}
+
+GridLines.propTypes = propTypes;
+GridLines.defaultProps = defaultProps;
+
+export default props => (
+  <ScalerContext.Consumer>
+    {({ series, subDomain, yTransformations }) => (
+      <GridLines
+        {...props}
+        series={series}
+        subDomain={subDomain}
+        yTransformations={yTransformations}
+      />
+    )}
+  </ScalerContext.Consumer>
+);

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import sizeMe from 'react-sizeme';
 import AxisCollection from '../AxisCollection';
+import GridLines from '../GridLines';
 import Scaler from '../Scaler';
 import ScalerContext from '../../context/Scaler';
 import { ScaledContextChart } from '../ContextChart';
@@ -12,6 +13,7 @@ import {
   annotationPropType,
   rulerPropType,
   axisDisplayModeType,
+  gridPropType,
 } from '../../utils/proptypes';
 import { ScaledLineCollection } from '../LineCollection';
 import InteractionLayer from '../InteractionLayer';
@@ -23,6 +25,7 @@ const propTypes = {
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
   }).isRequired,
+  grid: gridPropType,
   width: PropTypes.number,
   height: PropTypes.number,
   zoomable: PropTypes.bool,
@@ -63,6 +66,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  grid: null,
   zoomable: true,
   contextChart: {
     visible: true,
@@ -133,6 +137,7 @@ class LineChartComponent extends Component {
 
   render() {
     const {
+      grid,
       size: { width: sizeWidth, height: sizeHeight },
       width: propWidth,
       height: propHeight,
@@ -183,6 +188,11 @@ class LineChartComponent extends Component {
       >
         <div className="lines-container" style={{ height: '100%' }}>
           <svg width={chartSize.width} height={chartSize.height}>
+            <GridLines
+              grid={grid}
+              height={chartSize.height}
+              width={chartSize.width}
+            />
             <ScaledLineCollection
               height={chartSize.height}
               width={chartSize.width}

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -73,3 +73,87 @@ export const areaPropType = PropTypes.shape({
   start: coordinatePropType.isRequired,
   end: coordinatePropType,
 });
+
+/**
+ * Specification for the grid rendered under the data.
+ */
+export const gridPropType = PropTypes.shape({
+  /** Color of the lines (default: #000) */
+  color: PropTypes.string,
+  /** Thickness of the lines (default: 1) */
+  strokeWidth: PropTypes.number,
+  /** Opacity of the lines (default: 0.4) */
+  opacity: PropTypes.number,
+
+  /**
+   * Defines the behavior of the vertical grid lines (rendered from the X axis)
+   */
+  x: {
+    /** Render lines every X pixels */
+    pixels: PropTypes.number,
+
+    /**
+     * Render this many lines (approximatey). If this is `0`, then the lines
+     * will match the tick marks on the x axis.
+     */
+    count: PropTypes.number,
+
+    /**
+     * Color of the lines. If this is not specified, then the top-level color
+     * property will be used.
+     */
+    color: PropTypes.string,
+
+    /**
+     * Thickness of the lines. If this is not specified, then the top-level
+     * strokeWidth property will be used.
+     */
+    strokeWidth: PropTypes.number,
+
+    /**
+     * Opaccity of the lines. If this is not specified, then the top-level
+     * opacity property will be used.
+     */
+    opacity: PropTypes.number,
+  },
+
+  /**
+   * Defines the behavior of the horizontal grid lines (rendered from the Y
+   * axis)
+   */
+  y: {
+    /** Render lines every X pixels */
+    pixels: PropTypes.number,
+
+    /**
+     * The series ID to link these lines to for scaling purposes. This way they
+     * will be redrawn the y axis is zoomed, translated, etc.
+     */
+    seriesId: idPropType,
+
+    /**
+     * Render this many lines (approximatey). If this is `0`, then the lines
+     * will match the tick marks on the x axis.
+     */
+    count: PropTypes.number,
+
+    /**
+     * Color of the lines. If this is `null` (magic value), and `seriesId`
+     * points to a series, then that color will be used. However, if `seriesId`
+     * is not set, then the top-level color will be used.
+     */
+    color: PropTypes.string,
+
+    /**
+     * Thickness of the lines. If this is not specified, then the top-level
+     * strokeWidth property will be used.
+     */
+    strokeWidth: PropTypes.number,
+
+    /**
+     * Opaccity of the lines. If this is not specified, then the top-level
+     * opacity property will be used.
+     */
+    opacity: PropTypes.number,
+  },
+});

--- a/stories/GridLines.stories.js
+++ b/stories/GridLines.stories.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import 'react-select/dist/react-select.css';
+import { storiesOf } from '@storybook/react';
+import { DataProvider, LineChart } from '../src';
+import { staticLoader } from './loaders';
+
+const staticBaseDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
+const CHART_HEIGHT = 500;
+
+storiesOf('Grid Lines', module)
+  .add('Static horizontal lines every 35 pixels', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }]}
+    >
+      <LineChart height={CHART_HEIGHT} grid={{ y: { pixels: 35 } }} />
+    </DataProvider>
+  ))
+  .add('3 static horizontal lines', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }]}
+    >
+      <LineChart height={CHART_HEIGHT} grid={{ y: { count: 3 } }} />
+    </DataProvider>
+  ))
+  .add('Static vertical lines every 35 pixels', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }]}
+    >
+      <LineChart height={CHART_HEIGHT} grid={{ x: { pixels: 35 } }} />
+    </DataProvider>
+  ))
+  .add('3 static vertical lines', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }]}
+    >
+      <LineChart height={CHART_HEIGHT} grid={{ x: { count: 3 } }} />
+    </DataProvider>
+  ))
+  .add('Static grid lines every 75 pixels', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{ x: { pixels: 75 }, y: { pixels: 75 } }}
+      />
+    </DataProvider>
+  ))
+  .add('3 grid lines', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{ x: { count: 3 }, y: { count: 3 } }}
+      />
+    </DataProvider>
+  ))
+  .add('Dynamic horizontal lines', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }]}
+    >
+      <LineChart height={CHART_HEIGHT} grid={{ y: { seriesIds: [1] } }} />
+    </DataProvider>
+  ))
+  .add('Dynamic vertical lines', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }]}
+    >
+      <LineChart height={CHART_HEIGHT} grid={{ x: { ticks: 3 } }} />
+    </DataProvider>
+  ))
+  .add('Dynamic grid lines', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{ x: { ticks: 0 }, y: { seriesIds: [1] } }}
+      />
+    </DataProvider>
+  ))
+  .add('Dynamic grid lines (multiple series)', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{ x: { ticks: 0 }, y: { seriesIds: [1, 2], color: null } }}
+      />
+    </DataProvider>
+  ));

--- a/stories/GridLines.stories.js
+++ b/stories/GridLines.stories.js
@@ -109,4 +109,148 @@ storiesOf('Grid Lines', module)
         grid={{ x: { ticks: 0 }, y: { seriesIds: [1, 2], color: null } }}
       />
     </DataProvider>
-  ));
+  ))
+  .add('color', () => [
+    <DataProvider
+      key="y-dimension"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{ y: { count: 5, color: 'red' } }}
+      />
+    </DataProvider>,
+    <DataProvider
+      key="x-dimension"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{ x: { count: 5, color: 'red' } }}
+      />
+    </DataProvider>,
+    <DataProvider
+      key="grid-object"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{ color: 'red', x: { count: 5 }, y: { count: 5 } }}
+      />
+    </DataProvider>,
+    <DataProvider
+      key="different"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{
+          color: 'yellow',
+          x: { count: 5, color: 'orange' },
+          y: { count: 5, color: 'green' },
+        }}
+      />
+    </DataProvider>,
+  ])
+  .add('opacity', () => [
+    <DataProvider
+      key="y-dimension"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart height={CHART_HEIGHT} grid={{ y: { count: 5, opacity: 1 } }} />
+    </DataProvider>,
+    <DataProvider
+      key="x-dimension"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart height={CHART_HEIGHT} grid={{ x: { count: 5, opacity: 1 } }} />
+    </DataProvider>,
+    <DataProvider
+      key="grid-object"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{ opacity: 1, x: { count: 5 }, y: { count: 5 } }}
+      />
+    </DataProvider>,
+    <DataProvider
+      key="different"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{
+          opacity: 0,
+          x: { count: 5, opacity: 0.5 },
+          y: { count: 5, opacity: 1 },
+        }}
+      />
+    </DataProvider>,
+  ])
+  .add('strokeWidth', () => [
+    <DataProvider
+      key="y-dimension"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{ y: { count: 5, strokeWidth: 5 } }}
+      />
+    </DataProvider>,
+    <DataProvider
+      key="x-dimension"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{ x: { count: 5, strokeWidth: 5 } }}
+      />
+    </DataProvider>,
+    <DataProvider
+      key="grid-object"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{ strokeWidth: 5, x: { count: 5 }, y: { count: 5 } }}
+      />
+    </DataProvider>,
+    <DataProvider
+      key="different"
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        grid={{
+          strokeWidth: 15,
+          x: { count: 5, strokeWidth: 5 },
+          y: { count: 5, strokeWidth: 10 },
+        }}
+      />
+    </DataProvider>,
+  ]);


### PR DESCRIPTION
Expose a `grid` property on the LineChart which controls the grid line
specification. This object is documented in `proptypes.js`, but here's a
summary:

The `y` property of the grid specification controls how horizontal
lines behave (they're distributed along the Y values). These can either
be rendered statically or linked to one or more series. If there are
links, then the grid lines will be transformed just like the y-axis tick
marks as the data is scaled.

The `x` property of the grid specification controls how vertical lines
behave (they're distributed along the X values). Similarly, these can
either be rendered statically or linked to the time value. There is no
series linkage necessary for this, because the x-axis is independent of
the series being plotted.

Fixes #113