### PR TITLE
Do a build before releasing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "demo:build": "nwb build-react-component src/index.js",
     "lint": "eslint src",
     "prepush": "yarn lint",
-    "release": "node scripts/publish-release.js"
+    "release": "yarn build && node scripts/publish-release.js"
   },
   "dependencies": {
     "antd": "^3.4.1",


### PR DESCRIPTION
Publishing without building just publishes bad packages. Oops.