### PR TITLE
Don't use a default end for Area

### DIFF
--- a/src/components/Area/index.js
+++ b/src/components/Area/index.js
@@ -32,7 +32,7 @@ Area.propTypes = {
 Area.defaultProps = {
   color: '#000',
   opacity: 0.15,
-  end: { xpos: 0, ypos: 0 },
+  end: null,
 };
 
 export default Area;


### PR DESCRIPTION
If there is a default provided, then an initial area (from [0,0]) will
be drawn when when mousedown happens, until the mousemove is registered.

Default it to null so that we can detect this state and abort the
rendering.