### PR TITLE
Add a notion of ySubDomain

### DIFF
--- a/src/components/AxisCollection/YAxis.js
+++ b/src/components/AxisCollection/YAxis.js
@@ -29,7 +29,7 @@ const propTypes = {
 
 const defaultProps = {
   series: {},
-  collection: {},
+  collection: { id: 0, color: 'black' },
   zoomable: true,
   updateYTransformation: () => {},
   yTransformation: null,
@@ -54,8 +54,11 @@ export default class YAxis extends Component {
     }
     if (this.props.yTransformation) {
       if (
-        !isEqual(prevProps.series.yDomain, this.props.series.yDomain) ||
-        !isEqual(prevProps.collection.yDomain, this.props.collection.yDomain)
+        !isEqual(prevProps.series.ySubDomain, this.props.series.ySubDomain) ||
+        !isEqual(
+          prevProps.collection.ySubDomain,
+          this.props.collection.ySubDomain
+        )
       ) {
         this.selection.property('__zoom', this.props.yTransformation);
       }
@@ -191,7 +194,7 @@ export default class YAxis extends Component {
   renderAxis() {
     const { height } = this.props;
 
-    const scale = createYScale(this.getItem().yDomain, height);
+    const scale = createYScale(this.getItem().ySubDomain, height);
     const axis = d3.axisRight(scale);
     const tickFontSize = 14;
     const strokeWidth = 2;

--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -57,6 +57,7 @@ export default class ContextChart extends Component {
             width={width}
             height={height}
             domain={baseDomain}
+            scaleY={false}
           />
           <Brush
             width={width}

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -63,13 +63,14 @@ export default class DataProvider extends Component {
     loaderConfig: {},
     contextSeries: {},
     yDomains: {},
+    ySubDomains: {},
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
     // Check if one of the series got removed from props
     // If so, delete the respective keys in contextSeries and loaderconfig
     // This is important so we don't cache the vales if it gets readded later
-    const { loaderConfig, contextSeries, yDomains } = prevState;
+    const { loaderConfig, contextSeries, yDomains, ySubDomains } = prevState;
     const { series } = nextProps;
     const seriesKeys = {};
     series.forEach(s => {
@@ -78,6 +79,7 @@ export default class DataProvider extends Component {
     const newContextSeries = { ...contextSeries };
     const newLoaderConfig = { ...loaderConfig };
     const newYDomains = { ...yDomains };
+    const newYSubDomains = { ...ySubDomains };
     let shouldUpdate = false;
     Object.keys(loaderConfig).forEach(key => {
       if (!seriesKeys[key]) {
@@ -93,6 +95,7 @@ export default class DataProvider extends Component {
         loaderConfig: newLoaderConfig,
         contextSeries: newContextSeries,
         yDomains: newYDomains,
+        ySubDomains: newYSubDomains,
       };
     }
     return null;
@@ -159,6 +162,7 @@ export default class DataProvider extends Component {
           loaderConfig: {},
           contextSeries: {},
           yDomains: {},
+          ySubDomains: {},
         },
         async () => {
           await Promise.map(this.props.series, s =>
@@ -225,8 +229,14 @@ export default class DataProvider extends Component {
   };
 
   enrichSeries = (series, collection = {}) => {
-    const { yAccessor, y0Accessor, y1Accessor, xAccessor } = this.props;
-    const { loaderConfig, yDomains } = this.state;
+    const {
+      xAccessor,
+      y0Accessor,
+      y1Accessor,
+      yAccessor,
+      ySubDomain,
+    } = this.props;
+    const { loaderConfig, yDomains, ySubDomains } = this.state;
 
     const undefinedTruthiness = (a, b, c) => {
       if (a === undefined) {
@@ -237,6 +247,9 @@ export default class DataProvider extends Component {
       }
       return a;
     };
+    const yDomain = collection.yDomain ||
+      series.yDomain ||
+      yDomains[series.id] || [0, 0];
     return {
       drawPoints: collection.drawPoints,
       strokeWidth: collection.strokeWidth,
@@ -265,9 +278,13 @@ export default class DataProvider extends Component {
         y1Accessor
       ),
       yAxisDisplayMode: series.yAxisDisplayMode || collection.yAxisDisplayMode,
-      yDomain: collection.yDomain ||
-        series.yDomain ||
-        yDomains[series.id] || [0, 0],
+      yDomain,
+      ySubDomain:
+        collection.ySubDomain ||
+        series.ySubDomain ||
+        ySubDomains[series.id] ||
+        ySubDomain ||
+        yDomain,
     };
   };
 
@@ -304,7 +321,9 @@ export default class DataProvider extends Component {
         loaderConfig.y0Accessor || this.props.y0Accessor,
         loaderConfig.y1Accessor || this.props.y1Accessor
       );
+      const ySubDomain = yDomain;
       stateUpdates.yDomains = { ...this.state.yDomains, [id]: yDomain };
+      stateUpdates.ySubDomain = { ...this.state.ySubDomains, [id]: ySubDomain };
     }
     stateUpdates.loaderConfig = {
       ...this.state.loaderConfig,
@@ -357,6 +376,7 @@ export default class DataProvider extends Component {
     const collectionsWithDomains = collections
       .map(c => ({
         ...c,
+        // FIXME: This can be a single reduce call.
         yDomain: seriesObjects
           .filter(s => s.collectionId === c.id)
           .map(s => s.yDomain)
@@ -364,6 +384,17 @@ export default class DataProvider extends Component {
             (acc, yDomain) => [
               Math.min(acc[0], yDomain[0]),
               Math.max(acc[1], yDomain[1]),
+            ],
+            [Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER]
+          ),
+        // FIXME: This can be a single reduce call.
+        ySubDomain: seriesObjects
+          .filter(s => s.collectionId === c.id)
+          .map(s => s.ySubDomain)
+          .reduce(
+            (acc, ySubDomain) => [
+              Math.min(acc[0], ySubDomain[0]),
+              Math.max(acc[1], ySubDomain[1]),
             ],
             [Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER]
           ),
@@ -379,6 +410,10 @@ export default class DataProvider extends Component {
         s.collectionId !== undefined
           ? [...collectionsById[s.collectionId].yDomain]
           : s.yDomain,
+      ySubDomain:
+        s.collectionId !== undefined
+          ? [...collectionsById[s.collectionId].ySubDomain]
+          : s.ySubDomain,
     }));
 
     const context = {
@@ -414,6 +449,7 @@ DataProvider.propTypes = {
   y1Accessor: PropTypes.func,
   xAccessor: PropTypes.func,
   yAxisWidth: PropTypes.number,
+  ySubDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
   pointsPerSeries: PropTypes.number,
   children: PropTypes.node.isRequired,
   defaultLoader: PropTypes.func,
@@ -424,15 +460,16 @@ DataProvider.propTypes = {
 };
 
 DataProvider.defaultProps = {
+  collections: [],
+  defaultLoader: null,
+  onSubDomainChanged: null,
+  pointsPerSeries: 250,
+  subDomain: null,
   updateInterval: 0,
   xAccessor: d => d.timestamp,
-  yAccessor: d => d.value,
   y0Accessor: null,
   y1Accessor: null,
-  pointsPerSeries: 250,
+  yAccessor: d => d.value,
   yAxisWidth: 50,
-  defaultLoader: null,
-  subDomain: null,
-  onSubDomainChanged: null,
-  collections: [],
+  ySubDomain: null,
 };

--- a/src/components/LineCollection/index.js
+++ b/src/components/LineCollection/index.js
@@ -19,7 +19,10 @@ const LineCollection = props => {
     )
     .join('/')}`;
   const lines = series.filter(s => !s.hidden).map(s => {
-    const yScale = createYScale(s.yDomain, height);
+    const yScale = createYScale(
+      props.scaleY ? s.ySubDomain : s.yDomain,
+      height
+    );
     return (
       <Line
         key={s.id}
@@ -45,11 +48,15 @@ LineCollection.propTypes = {
   height: PropTypes.number.isRequired,
   series: seriesPropType,
   domain: PropTypes.arrayOf(PropTypes.number),
+  // Perform Y-scaling based on the current subdomain. If false, then use the
+  // static yDomain property.
+  scaleY: PropTypes.bool,
 };
 
 LineCollection.defaultProps = {
   series: [],
   domain: [0, 0],
+  scaleY: true,
 };
 
 export default LineCollection;

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -21,29 +21,29 @@ class Scaler extends Component {
   };
 
   state = {
-    yDomains: {},
+    ySubDomains: {},
     subDomain:
       this.props.dataContext.subDomain || this.props.dataContext.baseDomain,
     yTransformations: {},
   };
 
   componentDidUpdate(prevProps, prevState) {
-    // Check every serie if its yDomain changed
+    // Check every serie if its ySubDomain changed
     // If so -- update the state
-    const yDomains = {};
+    const ySubDomains = {};
     this.props.dataContext.series.forEach(s => {
-      yDomains[s.id] = s.yDomain;
+      ySubDomains[s.id] = s.ySubDomain;
     });
     const transformUpdate = {};
     const domainUpdate = {};
     prevProps.dataContext.series.forEach(s => {
-      if (!isEqual(yDomains[s.id], s.yDomain)) {
+      if (!isEqual(ySubDomains[s.id], s.ySubDomain)) {
         transformUpdate[s.id] = d3.zoomIdentity;
-        domainUpdate[s.id] = yDomains[s.id];
+        domainUpdate[s.id] = ySubDomains[s.id];
 
         if (s.collectionId) {
           transformUpdate[s.collectionId] = d3.zoomIdentity;
-          domainUpdate[s.collectionId] = yDomains[s.id];
+          domainUpdate[s.collectionId] = ySubDomains[s.id];
         }
       }
     });
@@ -68,8 +68,8 @@ class Scaler extends Component {
           ...this.state.yTransformations,
           ...transformUpdate,
         },
-        yDomains: {
-          ...this.state.yDomains,
+        ySubDomains: {
+          ...this.state.ySubDomains,
           ...domainUpdate,
         },
       });
@@ -95,7 +95,7 @@ class Scaler extends Component {
       // eslint-disable-next-line
       this.setState({
         subDomain: nextExternalBaseDomain,
-        yDomains: {},
+        ySubDomains: {},
         yTransformations: {},
       });
       return;
@@ -161,22 +161,22 @@ class Scaler extends Component {
   updateYTransformation = (key, scaler, height) => {
     const { dataContext } = this.props;
 
-    const { yDomain } =
+    const { ySubDomain } =
       dataContext.series.find(s => s.id === key) ||
       dataContext.collections.find(c => c.id === key);
     const newSubDomain = scaler
-      .rescaleY(createYScale(yDomain, height))
+      .rescaleY(createYScale(ySubDomain, height))
       .domain()
       .map(Number);
 
     this.setState({
-      yDomains: { ...this.state.yDomains, [key]: newSubDomain },
+      ySubDomains: { ...this.state.ySubDomains, [key]: newSubDomain },
       yTransformations: { ...this.state.yTransformations, [key]: scaler },
     });
   };
 
   render() {
-    const { yDomains, yTransformations, subDomain } = this.state;
+    const { ySubDomains, yTransformations, subDomain } = this.state;
     const { dataContext } = this.props;
     const ownContext = {
       updateXTransformation: this.updateXTransformation,
@@ -187,12 +187,12 @@ class Scaler extends Component {
 
     const enrichedSeries = dataContext.series.map(s => ({
       ...s,
-      yDomain: yDomains[s.id] || s.yDomain,
+      ySubDomain: ySubDomains[s.id] || s.ySubDomain,
     }));
 
     const enrichedCollections = dataContext.collections.map(c => ({
       ...c,
-      yDomain: yDomains[c.id] || c.yDomain,
+      ySubDomain: ySubDomains[c.id] || c.ySubDomain,
     }));
 
     const enrichedContext = {

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -17,6 +17,7 @@ export const singleSeriePropType = PropTypes.shape({
   y0Accessor: PropTypes.func,
   y1Accessor: PropTypes.func,
   yDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
+  ySubDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
   yAxisDisplayMode: PropTypes.shape({
     // See AxisDisplayMode
     id: PropTypes.string.isRequired,
@@ -93,7 +94,8 @@ const collection = PropTypes.shape({
   yAccessor: PropTypes.func,
   y0Accessor: PropTypes.func,
   y1Accessor: PropTypes.func,
-  yDomain: PropTypes.arrayOf(PropTypes.number),
+  yDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
+  ySubDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
 });
 
 const collections = PropTypes.arrayOf(collection);

--- a/stories/LineChart.stories.js
+++ b/stories/LineChart.stories.js
@@ -509,6 +509,7 @@ storiesOf('LineChart', module)
   })
   .add('ySubDomain', () => (
     <React.Fragment>
+      <h1>Set on DataProvider</h1>
       <DataProvider
         defaultLoader={staticLoader}
         baseDomain={staticBaseDomain}
@@ -517,6 +518,7 @@ storiesOf('LineChart', module)
       >
         <LineChart height={CHART_HEIGHT} />
       </DataProvider>
+      <h1>Set on Series</h1>
       <DataProvider
         defaultLoader={staticLoader}
         baseDomain={staticBaseDomain}
@@ -527,6 +529,7 @@ storiesOf('LineChart', module)
       >
         <LineChart height={CHART_HEIGHT} />
       </DataProvider>
+      <h1>Set on Collection</h1>
       <DataProvider
         defaultLoader={staticLoader}
         baseDomain={staticBaseDomain}
@@ -539,6 +542,26 @@ storiesOf('LineChart', module)
             ySubDomain: [0.25, 0.5],
           },
           { id: 4, collectionId: 'all', color: 'maroon' },
+        ]}
+      >
+        <LineChart height={CHART_HEIGHT} />
+      </DataProvider>
+      <h1>Set on Series with yDomain</h1>
+      <p>
+        The LineChart should be zoomed-in, but the context chart should be
+        zoomed-out
+      </p>
+      <DataProvider
+        defaultLoader={staticLoader}
+        baseDomain={staticBaseDomain}
+        series={[
+          {
+            id: 3,
+            color: 'steelblue',
+            ySubDomain: [0.25, 0.75],
+            yDomain: [-1, 2],
+          },
+          { id: 4, color: 'maroon' },
         ]}
       >
         <LineChart height={CHART_HEIGHT} />

--- a/stories/LineChart.stories.js
+++ b/stories/LineChart.stories.js
@@ -507,6 +507,44 @@ storiesOf('LineChart', module)
     }
     return <DynamicBaseDomain />;
   })
+  .add('ySubDomain', () => (
+    <React.Fragment>
+      <DataProvider
+        defaultLoader={staticLoader}
+        baseDomain={staticBaseDomain}
+        ySubDomain={[0.25, 0.5]}
+        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+      >
+        <LineChart height={CHART_HEIGHT} />
+      </DataProvider>
+      <DataProvider
+        defaultLoader={staticLoader}
+        baseDomain={staticBaseDomain}
+        series={[
+          { id: 3, color: 'steelblue', ySubDomain: [0.25, 0.5] },
+          { id: 4, color: 'maroon' },
+        ]}
+      >
+        <LineChart height={CHART_HEIGHT} />
+      </DataProvider>
+      <DataProvider
+        defaultLoader={staticLoader}
+        baseDomain={staticBaseDomain}
+        collections={[{ id: 'all', color: 'green', ySubDomain: [0.0, 0.5] }]}
+        series={[
+          {
+            id: 3,
+            collectionId: 'all',
+            color: 'steelblue',
+            ySubDomain: [0.25, 0.5],
+          },
+          { id: 4, collectionId: 'all', color: 'maroon' },
+        ]}
+      >
+        <LineChart height={CHART_HEIGHT} />
+      </DataProvider>
+    </React.Fragment>
+  ))
   .add('Dynamic sub domain', () => {
     const subDomainFirst = [
       Date.now() - 1000 * 60 * 60 * 24 * 20,


### PR DESCRIPTION
Support the y axis having a subdomain property, much like the x axis
does. In the interest of maintaining backwards compatibility, the
property was not renamed, but the equivalence is:

  baseDomain => yDomain
  subDomain  => ySubDomain

This can be specified on a series, collection, or on the `<DataProvider>`
element. The ySubDomain property is not respected on the context chart,
but otherwise replaces the yDomain property everywhere else.