### PR TITLE
Allow min/max area to be styled with CSS

### DIFF
--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -77,10 +77,12 @@ const Line = ({
           className="line-area"
           d={area(data)}
           style={{
-            stroke: 'none',
+            stroke: color,
+            strokeOpacity: 0,
             strokeWidth: `${strokeWidth}px`,
-            fill: `${color}`,
-            opacity: 0.25,
+            fill: color,
+            fillOpacity: 0.25,
+            opacity: 1,
             display: hidden ? 'none' : 'inherit',
           }}
         />


### PR DESCRIPTION
Expose all of the properties necessary so that client applications can
choose their own styles for the min/max area shade, if desired.