### PR TITLE
Allow the point width to be controlled

### DIFF
--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -15,6 +15,7 @@ const Line = ({
   hidden,
   drawPoints,
   strokeWidth,
+  pointWidth,
   clipPath,
 }) => {
   let line;
@@ -54,21 +55,23 @@ const Line = ({
   let circles = null;
   if (drawPoints) {
     const subDomain = xScale.domain().map(p => p.getTime());
-    circles = data
-      .filter(d => {
-        const x = xAccessor(d);
-        return x >= subDomain[0] && x <= subDomain[1];
-      })
-      .map(d => (
+    circles = data.reduce((points, d) => {
+      const x = xAccessor(d);
+      if (x < subDomain[0] || x > subDomain[1]) {
+        return points;
+      }
+      return [
+        ...points,
         <circle
           key={xAccessor(d)}
           className="line-circle"
-          r={3}
+          r={pointWidth / 2}
           cx={xScale(xAccessor(d))}
           cy={boundedSeries(yScale(yAccessor(d)))}
           fill={color}
-        />
-      ));
+        />,
+      ];
+    }, []);
   }
   return (
     <g clipPath={`url(#${clipPath})`}>
@@ -116,6 +119,7 @@ Line.propTypes = {
   step: PropTypes.bool,
   hidden: PropTypes.bool,
   drawPoints: PropTypes.bool,
+  pointWidth: PropTypes.number,
   strokeWidth: PropTypes.number,
   clipPath: PropTypes.string.isRequired,
 };
@@ -124,6 +128,7 @@ Line.defaultProps = {
   step: false,
   hidden: false,
   drawPoints: false,
+  pointWidth: 6,
   strokeWidth: 1,
   y0Accessor: null,
   y1Accessor: null,

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -67,6 +67,7 @@ const propTypes = {
   onAreaDefined: PropTypes.func,
   // (area, xpos, ypos) => shouldContinue
   onAreaClicked: PropTypes.func,
+  pointWidth: PropTypes.number,
 };
 
 const defaultProps = {
@@ -103,6 +104,7 @@ const defaultProps = {
   areas: [],
   onAreaDefined: null,
   onAreaClicked: null,
+  pointWidth: 6,
 };
 
 class LineChartComponent extends Component {
@@ -217,6 +219,7 @@ class LineChartComponent extends Component {
       onClickAnnotation,
       onDoubleClick,
       onMouseMove,
+      pointWidth,
       size: { width: sizeWidth, height: sizeHeight },
       subDomain,
       ruler,
@@ -252,6 +255,7 @@ class LineChartComponent extends Component {
             <ScaledLineCollection
               height={chartSize.height}
               width={chartSize.width}
+              pointWidth={pointWidth}
             />
             <InteractionLayer
               height={chartSize.height}

--- a/src/components/LineCollection/index.js
+++ b/src/components/LineCollection/index.js
@@ -7,7 +7,7 @@ import Line from '../Line';
 import AxisDisplayMode from '../LineChart/AxisDisplayMode';
 
 const LineCollection = props => {
-  const { series, width, height, domain } = props;
+  const { series, width, height, domain, pointWidth } = props;
   const xScale = createXScale(domain, width);
   const clipPath = `clip-path-${width}-${height}-${series
     .filter(s => !s.hidden)
@@ -18,21 +18,26 @@ const LineCollection = props => {
         }`
     )
     .join('/')}`;
-  const lines = series.filter(s => !s.hidden).map(s => {
+  const lines = series.reduce((l, s) => {
+    if (s.hidden) {
+      return l;
+    }
     const yScale = createYScale(
       props.scaleY ? s.ySubDomain : s.yDomain,
       height
     );
-    return (
+    return [
+      ...l,
       <Line
         key={s.id}
         {...s}
         xScale={xScale}
         yScale={yScale}
         clipPath={clipPath}
-      />
-    );
-  });
+        pointWidth={s.pointWidth || pointWidth}
+      />,
+    ];
+  }, []);
   return (
     <g width={width} height={height}>
       <clipPath id={clipPath}>
@@ -48,6 +53,7 @@ LineCollection.propTypes = {
   height: PropTypes.number.isRequired,
   series: seriesPropType,
   domain: PropTypes.arrayOf(PropTypes.number),
+  pointWidth: PropTypes.number,
   // Perform Y-scaling based on the current subdomain. If false, then use the
   // static yDomain property.
   scaleY: PropTypes.bool,
@@ -56,6 +62,7 @@ LineCollection.propTypes = {
 LineCollection.defaultProps = {
   series: [],
   domain: [0, 0],
+  pointWidth: 6,
   scaleY: true,
 };
 

--- a/stories/LineChart.stories.js
+++ b/stories/LineChart.stories.js
@@ -450,17 +450,41 @@ storiesOf('LineChart', module)
     );
   })
   .add('Draw points', () => (
-    <DataProvider
-      defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
-      pointsPerSeries={100}
-      series={[
-        { id: 1, color: 'steelblue' },
-        { id: 2, color: 'maroon', drawPoints: true },
-      ]}
-    >
-      <LineChart height={CHART_HEIGHT} />
-    </DataProvider>
+    <React.Fragment>
+      <DataProvider
+        defaultLoader={staticLoader}
+        baseDomain={staticBaseDomain}
+        pointsPerSeries={100}
+        series={[
+          { id: 1, color: 'steelblue' },
+          { id: 2, color: 'maroon', drawPoints: true },
+        ]}
+      >
+        <LineChart height={CHART_HEIGHT} />
+      </DataProvider>
+      <DataProvider
+        defaultLoader={staticLoader}
+        baseDomain={staticBaseDomain}
+        pointsPerSeries={100}
+        series={[
+          { id: 1, color: 'steelblue' },
+          { id: 2, color: 'maroon', drawPoints: true, pointWidth: 10 },
+        ]}
+      >
+        <LineChart height={CHART_HEIGHT} />
+      </DataProvider>
+      <DataProvider
+        defaultLoader={staticLoader}
+        baseDomain={staticBaseDomain}
+        pointsPerSeries={100}
+        series={[
+          { id: 1, color: 'steelblue' },
+          { id: 2, color: 'maroon', drawPoints: true },
+        ]}
+      >
+        <LineChart height={CHART_HEIGHT} pointWidth={4} />
+      </DataProvider>
+    </React.Fragment>
   ))
   .add('Without context chart', () => (
     <DataProvider


### PR DESCRIPTION
Much like the calling application can control the stroke width, they can
also control the width of the points being rendered. This is done with a
new pointWidth property, which can be set on either the LineChart or a
series object.