### PR TITLE
Add point-hovering capabilities

### DIFF
--- a/src/components/Points/index.js
+++ b/src/components/Points/index.js
@@ -14,6 +14,8 @@ const propTypes = {
   xScale: scaleFuncPropType.isRequired,
   yScale: scaleFuncPropType.isRequired,
   color: PropTypes.string.isRequired,
+  // (nullableData, e) => void
+  onPointHover: PropTypes.func,
   opacity: PropTypes.number,
   opacityAccessor: PropTypes.func,
   pointWidth: PropTypes.number,
@@ -21,6 +23,7 @@ const propTypes = {
   strokeWidth: PropTypes.number,
 };
 const defaultProps = {
+  onPointHover: null,
   opacity: 1,
   opacityAccessor: null,
   pointWidth: null,
@@ -29,17 +32,18 @@ const defaultProps = {
 };
 
 const Points = ({
-  data,
-  xAccessor,
-  yAccessor,
-  xScale,
-  yScale,
   color,
+  data,
+  onPointHover,
   opacity,
   opacityAccessor,
   pointWidth,
   pointWidthAccessor,
   strokeWidth,
+  xAccessor,
+  xScale,
+  yAccessor,
+  yScale,
 }) => {
   const points = data.map(d => {
     let width = 0;
@@ -61,6 +65,10 @@ const Points = ({
         cx={boundedSeries(xScale(xAccessor(d)))}
         cy={boundedSeries(yScale(yAccessor(d)))}
         fill={color}
+        onMouseEnter={onPointHover ? e => onPointHover(d, e) : null}
+        onMouseLeave={onPointHover ? e => onPointHover(null, e) : null}
+        onFocus={onPointHover ? e => onPointHover(d, e) : null}
+        onBlur={onPointHover ? e => onPointHover(null, e) : null}
       />
     );
   });

--- a/src/components/Scatterplot/index.js
+++ b/src/components/Scatterplot/index.js
@@ -87,7 +87,6 @@ const ScatterplotComponent = ({
       chart={
         <svg style={{ width: '100%', height: '100%' }}>
           <GridLines grid={grid} {...chartSize} />
-          <ScaledPointCollection {...chartSize} />
           <InteractionLayer
             {...chartSize}
             zoomable={zoomable}
@@ -95,6 +94,7 @@ const ScatterplotComponent = ({
             zoomMode={ZoomMode.BOTH}
             xScalerFactory={xScalerFactory}
           />
+          <ScaledPointCollection {...chartSize} />
         </svg>
       }
       yAxis={

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -12,6 +12,8 @@ export const singleSeriePropType = PropTypes.shape({
   strokeWidth: PropTypes.number,
   drawPoints: PropTypes.bool,
   loader: PropTypes.func,
+  // (data, e) => void
+  onPointHover: PropTypes.func,
   step: PropTypes.bool,
   xAccessor: PropTypes.func,
   yAccessor: PropTypes.func,


### PR DESCRIPTION
Add a callback function to the series object: onPointHover. This is
called whenever the point is hovered (or un-hovered) to allow the
application to respond accordingly.

This change also puts the points on top of the InteractionLayer for
scatterplots. Without this change, the hovering functionality is blocked
by the InteractionLayer. However, zooming is blocked when on top of a
point.