### PR TITLE
Copy the loaderConfig data before the series data

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -216,8 +216,8 @@ export default class DataProvider extends Component {
     const { loaderConfig, yDomains } = this.state;
     return {
       data: [],
-      ...deleteUndefinedFromObject(series),
       ...deleteUndefinedFromObject(loaderConfig[series.id]),
+      ...deleteUndefinedFromObject(series),
       xAccessor: series.xAccessor || xAccessor,
       yAccessor: series.yAccessor || yAccessor,
       y0Accessor: series.y0Accessor || y0Accessor,


### PR DESCRIPTION
The series object (sourced from props) has the most up-to-date
information about the series (eg: hidden, colors, etc). These should not
be trampled by properties that are stored in the loaderConfig copy.