### PR TITLE
fetch data in DataProvider on pointsPerSeries prop update

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ DataProvider.propTypes = {
   yAccessor: PropTypes.func,
   xAccessor: PropTypes.func,
   yAxisWidth: PropTypes.number,
-  pointPerSeries: PropTypes.number,
+  pointsPerSeries: PropTypes.number,
   children: PropTypes.node.isRequired,
   defaultLoader: PropTypes.func,
   series: seriesPropType.isRequired,
@@ -77,6 +77,7 @@ INTERVAL, // If you specify an update interval, it will be called every n second
 NEW_LOADER, // The loader function changed
 NEW_DOMAIN, // The outer domain changed,
 NEW_SUBDOMAIN, // The user zoomed to a new subdomain.
+UPDATE_POINTS_PER_SERIES, // The pointsPerSeries prop has changed
 ```
 
 The simplest loader simply delivers static data and would look like this:

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -131,6 +131,14 @@ export default class DataProvider extends Component {
         this.startUpdateInterval();
       }
     }
+
+    // check if pointsPerSeries changed in props -- if so fetch new data
+    if (!isEqual(this.props.pointsPerSeries, prevProps.pointsPerSeries)) {
+      await Promise.map(this.props.series, s =>
+        this.fetchData(s.id, 'UPDATE_POINTS_PER_SERIES')
+      );
+    }
+
     const { series: prevSeries } = prevProps;
     if (!prevSeries) {
       return;

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -133,7 +133,7 @@ export default class DataProvider extends Component {
     }
 
     // check if pointsPerSeries changed in props -- if so fetch new data
-    if (!isEqual(this.props.pointsPerSeries, prevProps.pointsPerSeries)) {
+    if (this.props.pointsPerSeries !== prevProps.pointsPerSeries) {
       await Promise.map(this.props.series, s =>
         this.fetchData(s.id, 'UPDATE_POINTS_PER_SERIES')
       );


### PR DESCRIPTION
`DataProvider` should fetch new data when its `pointsPerSeries` prop is updated so that it can be more responsive (e.g. to window resizing).