### PR TITLE
Support custom tick formatting

### DIFF
--- a/src/components/AxisCollection/YAxis.js
+++ b/src/components/AxisCollection/YAxis.js
@@ -22,6 +22,8 @@ const propTypes = {
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
   yAxisPlacement: GriffPropTypes.axisPlacement,
+  // Number => String
+  tickFormatter: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -194,7 +196,7 @@ export default class YAxis extends Component {
   }
 
   renderAxis() {
-    const { height } = this.props;
+    const { height, tickFormatter } = this.props;
 
     const item = this.getItem();
     const scale = createYScale(item.ySubDomain, height);
@@ -208,11 +210,10 @@ export default class YAxis extends Component {
     // same as for xAxis but consider height of the screen ~two times smaller
     const nTicks = Math.floor(height / 50) || 1;
     const values = scale.ticks(nTicks);
-    const tickFormat = scale.tickFormat(nTicks);
     const range = scale.range().map(r => r + halfStrokeWidth);
     return (
       <g
-        className="axis"
+        className="axis y-axis"
         fill="none"
         fontSize={tickFontSize}
         textAnchor={this.getTextAnchor()}
@@ -236,7 +237,9 @@ export default class YAxis extends Component {
           return (
             <g key={+v} opacity={1} transform={`translate(0, ${scale(v)})`}>
               <line {...lineProps} />
-              <text {...textProps}>{tickFormat(v)}</text>
+              <text className="tick-value" {...textProps}>
+                {tickFormatter(v)}
+              </text>
             </g>
           );
         })}

--- a/src/components/AxisCollection/index.js
+++ b/src/components/AxisCollection/index.js
@@ -28,6 +28,8 @@ const propTypes = {
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
   yAxisPlacement: GriffPropTypes.axisPlacement,
+  // Number => String
+  tickFormatter: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -98,6 +100,7 @@ class AxisCollection extends React.Component {
       series,
       zoomable,
       height,
+      tickFormatter,
       updateYTransformation,
       yAxisPlacement,
       yAxisWidth,
@@ -143,6 +146,7 @@ class AxisCollection extends React.Component {
               yTransformation={yTransformations[s.id]}
               onMouseEnter={this.onAxisMouseEnter(s.id)}
               onMouseLeave={this.onAxisMouseLeave(s.id)}
+              tickFormatter={tickFormatter}
               yAxisPlacement={yAxisPlacement}
             />
           );
@@ -176,6 +180,7 @@ class AxisCollection extends React.Component {
               yTransformation={yTransformations[c.id]}
               onMouseEnter={this.onAxisMouseEnter(c.id)}
               onMouseLeave={this.onAxisMouseLeave(c.id)}
+              tickFormatter={tickFormatter}
               yAxisPlacement={yAxisPlacement}
             />
           );

--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -23,6 +23,8 @@ export default class ContextChart extends Component {
     updateSubDomain: PropTypes.func.isRequired,
     zoomable: PropTypes.bool,
     xScalerFactory: scalerFactoryFunc.isRequired,
+    // Number => String
+    xAxisFormatter: PropTypes.func,
     xAxisHeight: PropTypes.number,
     xAxisPlacement: GriffPropTypes.axisPlacement,
   };
@@ -31,6 +33,7 @@ export default class ContextChart extends Component {
     annotations: [],
     contextSeries: [],
     zoomable: true,
+    xAxisFormatter: null,
     xAxisHeight: 50,
     xAxisPlacement: AxisPlacement.BOTTOM,
   };
@@ -69,6 +72,7 @@ export default class ContextChart extends Component {
       baseDomain,
       subDomain,
       contextSeries,
+      xAxisFormatter,
       xAxisHeight,
       xAxisPlacement,
       xScalerFactory,
@@ -86,6 +90,7 @@ export default class ContextChart extends Component {
         width={width}
         height={xAxisHeight}
         domain={baseDomain}
+        tickFormatter={xAxisFormatter}
         xAxisPlacement={xAxisPlacement}
         xScalerFactory={xScalerFactory}
       />

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import sizeMe from 'react-sizeme';
+import * as d3 from 'd3';
 import AxisCollection from '../AxisCollection';
 import GridLines from '../GridLines';
 import Scaler from '../Scaler';
@@ -20,6 +21,34 @@ import XAxis from '../XAxis';
 import AxisDisplayMode from './AxisDisplayMode';
 import AxisPlacement from '../AxisPlacement';
 import Layout from './Layout';
+
+const formatMillisecond = d3.timeFormat('.%L');
+const formatSecond = d3.timeFormat(':%S');
+const formatMinute = d3.timeFormat('%H:%M');
+const formatHour = d3.timeFormat('%H:00');
+const formatDay = d3.timeFormat('%d/%m');
+const formatWeek = d3.timeFormat('%d/%m');
+const formatMonth = d3.timeFormat('%d/%m');
+const formatYear = d3.timeFormat('%b %Y');
+
+function multiFormat(date) {
+  /* eslint-disable no-nested-ternary */
+  return (d3.timeSecond(date) < date
+    ? formatMillisecond
+    : d3.timeMinute(date) < date
+      ? formatSecond
+      : d3.timeHour(date) < date
+        ? formatMinute
+        : d3.timeDay(date) < date
+          ? formatHour
+          : d3.timeMonth(date) < date
+            ? d3.timeWeek(date) < date
+              ? formatDay
+              : formatWeek
+            : d3.timeYear(date) < date
+              ? formatMonth
+              : formatYear)(date);
+}
 
 const propTypes = {
   size: PropTypes.shape({
@@ -47,6 +76,8 @@ const propTypes = {
   contextChart: GriffPropTypes.contextChart,
   ruler: rulerPropType,
   annotations: PropTypes.arrayOf(annotationPropType),
+  // Number => String
+  yAxisFormatter: PropTypes.func,
   xAxisPlacement: GriffPropTypes.axisPlacement,
   yAxisDisplayMode: axisDisplayModeType,
   yAxisPlacement: GriffPropTypes.axisPlacement,
@@ -72,6 +103,8 @@ const propTypes = {
   // (area, xpos, ypos) => shouldContinue
   onAreaClicked: PropTypes.func,
   pointWidth: PropTypes.number,
+  // Number => String
+  xAxisFormatter: PropTypes.func,
 };
 
 const defaultProps = {
@@ -101,8 +134,10 @@ const defaultProps = {
   width: 0,
   height: 0,
   subDomain: [],
+  xAxisFormatter: multiFormat,
   xAxisPlacement: AxisPlacement.BOTTOM,
   yAxisDisplayMode: AxisDisplayMode.ALL,
+  yAxisFormatter: Number,
   yAxisPlacement: AxisPlacement.RIGHT,
   onAxisMouseEnter: null,
   onAxisMouseLeave: null,
@@ -232,8 +267,10 @@ class LineChartComponent extends Component {
       width: propWidth,
       xScalerFactory,
       xAxisHeight,
+      xAxisFormatter,
       xAxisPlacement,
       yAxisDisplayMode,
+      yAxisFormatter,
       zoomable,
     } = this.props;
 
@@ -289,6 +326,7 @@ class LineChartComponent extends Component {
             onMouseEnter={onAxisMouseEnter}
             onMouseLeave={onAxisMouseLeave}
             height={chartSize.height}
+            tickFormatter={yAxisFormatter}
           />
         }
         xAxis={
@@ -298,6 +336,7 @@ class LineChartComponent extends Component {
             xScalerFactory={xScalerFactory}
             height={xAxisHeight}
             xAxisPlacement={xAxisPlacement}
+            tickFormatter={xAxisFormatter}
           />
         }
         contextChart={
@@ -307,6 +346,7 @@ class LineChartComponent extends Component {
               width={chartSize.width}
               zoomable={zoomable}
               annotations={annotations}
+              xAxisFormatter={xAxisFormatter}
               xAxisHeight={xAxisHeight}
               xAxisPlacement={xAxisPlacement}
             />

--- a/src/components/Scatterplot/index.js
+++ b/src/components/Scatterplot/index.js
@@ -25,10 +25,14 @@ const propTypes = {
   zoomable: PropTypes.bool,
   onClick: PropTypes.func,
   series: seriesPropType.isRequired,
+  // Number => String
+  xAxisFormatter: PropTypes.func,
   xAxisPlacement: GriffPropTypes.axisPlacement,
   xAxisTicks: PropTypes.number,
   xScalerFactory: scalerFactoryFunc.isRequired,
   subDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  // Number => String
+  yAxisFormatter: PropTypes.func,
   yAxisPlacement: GriffPropTypes.axisPlacement,
   yAxisTicks: PropTypes.number,
 };
@@ -37,8 +41,10 @@ const defaultProps = {
   grid: null,
   zoomable: true,
   onClick: null,
+  xAxisFormatter: Number,
   xAxisPlacement: AxisPlacement.BOTTOM,
   xAxisTicks: null,
+  yAxisFormatter: Number,
   yAxisPlacement: AxisPlacement.RIGHT,
   yAxisTicks: null,
 };
@@ -52,9 +58,11 @@ const ScatterplotComponent = ({
   series,
   zoomable,
   onClick,
+  xAxisFormatter,
   xAxisPlacement,
   xAxisTicks,
   xScalerFactory,
+  yAxisFormatter,
   yAxisPlacement,
   yAxisTicks,
   subDomain,
@@ -99,6 +107,7 @@ const ScatterplotComponent = ({
       }
       yAxis={
         <UnifiedAxis
+          tickFormatter={yAxisFormatter}
           yAxisPlacement={yAxisPlacement}
           series={series}
           height={chartSize.height}
@@ -112,7 +121,7 @@ const ScatterplotComponent = ({
           width={chartSize.width}
           height={X_AXIS_HEIGHT}
           xScalerFactory={xScalerFactory}
-          tickFormatter={Number}
+          tickFormatter={xAxisFormatter}
           ticks={xAxisTicks}
         />
       }

--- a/src/components/UnifiedAxis/CombinedYAxis.js
+++ b/src/components/UnifiedAxis/CombinedYAxis.js
@@ -11,6 +11,8 @@ const propTypes = {
   width: PropTypes.number.isRequired,
   color: PropTypes.string,
   ticks: PropTypes.number,
+  // Number => String
+  tickFormatter: PropTypes.func.isRequired,
   yAxisPlacement: GriffPropTypes.axisPlacement,
 };
 
@@ -125,7 +127,7 @@ export default class CombinedYAxis extends Component {
   };
 
   renderAxis() {
-    const { series, height, color, ticks } = this.props;
+    const { series, height, color, ticks, tickFormatter } = this.props;
     const scale = createYScale(this.getDomain(series), height);
     const axis = d3.axisRight(scale);
     const tickFontSize = 14;
@@ -137,7 +139,6 @@ export default class CombinedYAxis extends Component {
     // same as for xAxis but consider height of the screen ~two times smaller
     const nTicks = ticks || Math.floor(height / 50) || 1;
     const values = scale.ticks(nTicks);
-    const tickFormat = scale.tickFormat(nTicks);
     const range = scale.range().map(r => r + halfStrokeWidth);
     return (
       <g
@@ -165,7 +166,7 @@ export default class CombinedYAxis extends Component {
           return (
             <g key={+v} opacity={1} transform={`translate(0, ${scale(v)})`}>
               <line {...lineProps} />
-              <text {...textProps}>{tickFormat(v)}</text>
+              <text {...textProps}>{tickFormatter(v)}</text>
             </g>
           );
         })}

--- a/src/components/UnifiedAxis/index.js
+++ b/src/components/UnifiedAxis/index.js
@@ -12,6 +12,8 @@ const propTypes = {
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
   ticks: PropTypes.number,
+  // Number => String
+  tickFormatter: PropTypes.func.isRequired,
   yAxisPlacement: GriffPropTypes.axisPlacement,
 };
 const defaultProps = {
@@ -32,6 +34,7 @@ class UnifiedAxis extends React.Component {
       onMouseEnter,
       onMouseLeave,
       ticks,
+      tickFormatter,
       yAxisPlacement,
     } = this.props;
     return (
@@ -48,6 +51,7 @@ class UnifiedAxis extends React.Component {
           width={width}
           height={height}
           ticks={ticks}
+          tickFormatter={tickFormatter}
           yAxisPlacement={yAxisPlacement}
         />
       </svg>

--- a/src/components/XAxis.js
+++ b/src/components/XAxis.js
@@ -6,41 +6,13 @@ import AxisPlacement from './AxisPlacement';
 
 const tickTransformer = v => `translate(${v}, 0)`;
 
-const formatMillisecond = d3.timeFormat('.%L');
-const formatSecond = d3.timeFormat(':%S');
-const formatMinute = d3.timeFormat('%H:%M');
-const formatHour = d3.timeFormat('%H:00');
-const formatDay = d3.timeFormat('%d/%m');
-const formatWeek = d3.timeFormat('%d/%m');
-const formatMonth = d3.timeFormat('%d/%m');
-const formatYear = d3.timeFormat('%b %Y');
-
-function multiFormat(date) {
-  /* eslint-disable no-nested-ternary */
-  return (d3.timeSecond(date) < date
-    ? formatMillisecond
-    : d3.timeMinute(date) < date
-      ? formatSecond
-      : d3.timeHour(date) < date
-        ? formatMinute
-        : d3.timeDay(date) < date
-          ? formatHour
-          : d3.timeMonth(date) < date
-            ? d3.timeWeek(date) < date
-              ? formatDay
-              : formatWeek
-            : d3.timeYear(date) < date
-              ? formatMonth
-              : formatYear)(date);
-}
-
 const propTypes = {
   domain: PropTypes.arrayOf(PropTypes.number).isRequired,
   strokeColor: PropTypes.string,
   width: PropTypes.number.isRequired,
   height: PropTypes.number,
   // Number => String
-  tickFormatter: PropTypes.func,
+  tickFormatter: PropTypes.func.isRequired,
   ticks: PropTypes.number,
   xAxisPlacement: GriffPropTypes.axisPlacement,
   xScalerFactory: scalerFactoryFunc.isRequired,
@@ -49,7 +21,6 @@ const propTypes = {
 const defaultProps = {
   strokeColor: 'black',
   height: 50,
-  tickFormatter: multiFormat,
   ticks: null,
   xAxisPlacement: AxisPlacement.BOTTOM,
 };
@@ -122,7 +93,7 @@ class Axis extends Component {
       width,
       strokeColor,
       xScalerFactory,
-      tickFormatter = multiFormat,
+      tickFormatter,
       ticks,
     } = this.props;
     const scale = xScalerFactory(domain, width);
@@ -147,7 +118,7 @@ class Axis extends Component {
     });
     return (
       <g
-        className="x-axis"
+        className="axis x-axis"
         fill="none"
         fontSize={tickFontSize}
         textAnchor="middle"
@@ -168,7 +139,9 @@ class Axis extends Component {
           return (
             <g key={+v} opacity={1} transform={tickTransformer(scale(v))}>
               <line stroke={strokeColor} {...lineProps} />
-              <text {...textProps}>{tickFormatter(v)}</text>
+              <text className="tick-value" {...textProps}>
+                {tickFormatter(v)}
+              </text>
             </g>
           );
         })}

--- a/stories/LineChart.stories.js
+++ b/stories/LineChart.stories.js
@@ -35,6 +35,19 @@ storiesOf('LineChart', module)
       <LineChart height={CHART_HEIGHT} />
     </DataProvider>
   ))
+  .add('Custom tick formatting', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      baseDomain={staticBaseDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        xAxisFormatter={n => n / 1000}
+        yAxisFormatter={n => n * 1000}
+      />
+    </DataProvider>
+  ))
   .add('Multiple', () => (
     <React.Fragment>
       <DataProvider

--- a/stories/Scatterplot.stories.js
+++ b/stories/Scatterplot.stories.js
@@ -138,6 +138,25 @@ storiesOf('Scatterplot', module)
       </div>
     </React.Fragment>
   ))
+  .add('Custom tick formatting', () => (
+    <React.Fragment>
+      <div style={{ height: '500px', width: '100%' }}>
+        <DataProvider
+          defaultLoader={scatterplotloader}
+          baseDomain={[0, 1]}
+          series={[{ id: '1 2', color: 'steelblue' }]}
+          xAccessor={d => +d.x}
+          yAccessor={d => +d.y}
+        >
+          <Scatterplot
+            zoomable
+            xAxisFormatter={n => n.toFixed(3)}
+            yAxisFormatter={n => n.toFixed(2)}
+          />
+        </DataProvider>
+      </div>
+    </React.Fragment>
+  ))
   .add('Grid', () => (
     <div style={{ height: '500px', width: '500px' }}>
       <DataProvider


### PR DESCRIPTION
Add properties to allow for custom-rendering the tick values on both the
x and y axes. These are specified by the `xAxisFormatter` and
`yAxisFormatter` props on the `LineChart` and `Scatterplot` components.