### PR TITLE
Copy the series properies after the loader props

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -261,8 +261,8 @@ export default class DataProvider extends Component {
       drawPoints: collection.drawPoints,
       hidden: collection.hidden,
       data: [],
-      ...deleteUndefinedFromObject(series),
       ...deleteUndefinedFromObject(loaderConfig[series.id]),
+      ...deleteUndefinedFromObject(series),
       xAccessor: firstDefined(
         series.xAccessor,
         collection.xAccessor,

--- a/stories/loaders.js
+++ b/stories/loaders.js
@@ -52,7 +52,7 @@ export const staticLoader = ({
   }
   // Otherwise, return the existing dataset.
   return {
-    data: oldSeries.data,
+    ...oldSeries,
   };
 };
 


### PR DESCRIPTION
When the loader returns data, it gets copied into the enriched series.
This needs to happen before copying the series information from the
props, or else old information will be retained and clobber the
potentiall-changed data coming in from the props.

This was never caught because the storybook loader does not spread the
`oldSeries` object, and instead only returns the `data` property.