### PR TITLE
add onBaseDomainChanged to DataProvider

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -51,9 +51,10 @@ const getSubDomain = (baseDomain, subDomain) => {
   if (!subDomain) {
     return baseDomain;
   }
-  const minDomain = Math.max(subDomain[0], baseDomain[0]);
-  const maxDomain = Math.min(subDomain[1], baseDomain[1]);
-  return [minDomain, maxDomain];
+  const subDomainLength = subDomain[1] - subDomain[0];
+  const end = Math.min(subDomain[1], baseDomain[1]);
+  const start = Math.max(end - subDomainLength, baseDomain[0]);
+  return [start, end];
 };
 
 /**
@@ -239,6 +240,9 @@ export default class DataProvider extends Component {
             baseDomain: baseDomain.map(d => d + updateInterval),
           },
           () => {
+            if (this.props.onBaseDomainChanged) {
+              this.props.onBaseDomainChanged(this.state.baseDomain);
+            }
             Promise.map(this.props.series, s =>
               this.fetchData(s.id, 'INTERVAL')
             );
@@ -404,6 +408,7 @@ export default class DataProvider extends Component {
       subDomain: externalSubDomain,
       collections,
     } = this.props;
+
     if (Object.keys(loaderConfig).length === 0) {
       // Do not bother, loader hasn't given any data yet.
       return null;
@@ -518,6 +523,7 @@ DataProvider.propTypes = {
   collections: GriffPropTypes.collections,
   // (subDomain) => null
   onSubDomainChanged: PropTypes.func,
+  onBaseDomainChanged: PropTypes.func,
   opacity: PropTypes.number,
   opacityAccessor: PropTypes.func,
   pointWidth: PropTypes.number,
@@ -529,6 +535,7 @@ DataProvider.defaultProps = {
   collections: [],
   defaultLoader: null,
   onSubDomainChanged: null,
+  onBaseDomainChanged: null,
   opacity: 1.0,
   opacityAccessor: null,
   pointsPerSeries: 250,

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -202,6 +202,9 @@ export default class DataProvider extends Component {
       if (this.props.onSubDomainChanged) {
         this.props.onSubDomainChanged(newSubDomain);
       }
+      if (this.props.onBaseDomainChanged) {
+        this.props.onBaseDomainChanged(this.props.baseDomain);
+      }
       if (this.fetchInterval) {
         clearInterval(this.fetchInterval);
       }

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -47,14 +47,22 @@ const deleteUndefinedFromObject = obj => {
 };
 
 // make sure that passed subDomain is part of baseDomain
-const getSubDomain = (baseDomain, subDomain) => {
+export const getSubDomain = (baseDomain, subDomain) => {
   if (!subDomain) {
     return baseDomain;
   }
+  const baseDomainLength = baseDomain[1] - baseDomain[0];
   const subDomainLength = subDomain[1] - subDomain[0];
-  const end = Math.min(subDomain[1], baseDomain[1]);
-  const start = Math.max(end - subDomainLength, baseDomain[0]);
-  return [start, end];
+  if (baseDomainLength < subDomainLength) {
+    return baseDomain;
+  }
+  if (subDomain[0] < baseDomain[0]) {
+    return [baseDomain[0], baseDomain[0] + subDomainLength];
+  }
+  if (subDomain[1] > baseDomain[1]) {
+    return [baseDomain[1] - subDomainLength, baseDomain[1]];
+  }
+  return subDomain;
 };
 
 /**

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -113,7 +113,10 @@ class Scaler extends Component {
       // The internal baseDomain changed
       // Keep existing subdomain
       const { subDomain } = prevState;
-      if (subDomain && subDomain[1] === prevBaseDomain[1]) {
+      if (
+        (subDomain && subDomain[1] === prevBaseDomain[1]) ||
+        subDomain[1] >= prevBaseDomain[1]
+      ) {
         // You are looking at the end of the window
         // and the baseDomain is updated
         // Lock the subDomain to the end of the window

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
-export { default as DataProvider } from './components/DataProvider';
+export {
+  default as DataProvider,
+  getSubDomain,
+} from './components/DataProvider';
 export { default as ContextChart } from './components/ContextChart';
 export { default as LineChart } from './components/LineChart';
 export {

--- a/stories/LineChart.stories.js
+++ b/stories/LineChart.stories.js
@@ -589,6 +589,7 @@ storiesOf('LineChart', module)
                 { id: 2, color: 'maroon' },
               ]}
               baseDomain={baseDomain}
+              onBaseDomainChanged={action('base domain changed')}
             >
               <LineChart height={CHART_HEIGHT} />
             </DataProvider>

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -1,38 +1,34 @@
 import expect from 'expect';
-import React from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
+import { getSubDomain } from 'src/';
 
-import { DataProvider, ChartContainer } from 'src/';
-
-describe('Component', () => {
-  let node;
-
-  beforeEach(() => {
-    node = document.createElement('div');
+describe('getSubDomain', () => {
+  it('handles the base case', () => {
+    const baseDomain = [0, 100];
+    const subDomain = [25, 75];
+    expect(getSubDomain(baseDomain, subDomain)).toMatch(subDomain);
   });
 
-  afterEach(() => {
-    unmountComponentAtNode(node);
+  it('handles when the subdomain goes longer', () => {
+    const baseDomain = [50, 100];
+    const subDomain = [95, 105];
+    expect(getSubDomain(baseDomain, subDomain)).toMatch([90, 100]);
   });
 
-  it('Renders dataprovider', () => {
-    const config = {
-      yAxis: {
-        width: 50,
-        mode: 'every',
-        accessor: d => d.value
-      },
-      xAxis: {
-        accessor: d => d.timestamp
-      },
-      baseDomain: [Date.now() - 1000, Date.now()]
-    };
-    render(
-      <DataProvider config={config} width={1000} height={500}>
-        <ChartContainer />
-      </DataProvider>,
-      node,
-      console.log
-    );
+  it('handles when the subdomain goes shorter', () => {
+    const baseDomain = [50, 100];
+    const subDomain = [45, 55];
+    expect(getSubDomain(baseDomain, subDomain)).toMatch([50, 60]);
+  });
+
+  it('handles when the subdomain is outside', () => {
+    const baseDomain = [50, 100];
+    const subDomain = [150, 160];
+    expect(getSubDomain(baseDomain, subDomain)).toMatch([90, 100]);
+  });
+
+  it('handles when the subdomain is longer than the domain', () => {
+    const baseDomain = [50, 100];
+    const subDomain = [25, 125];
+    expect(getSubDomain(baseDomain, subDomain)).toMatch([50, 100]);
   });
 });


### PR DESCRIPTION
- add an `onBaseDomainChanged` prop to `DataProvider`
- allow subDomain to be > baseDomain when checking if we are looking at the front of the window
- maintain initial subDomain length in `getSubdomain`