### PR TITLE
Introduce xDomain and xSubDomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The outermost component in the hierarchy. The DataProvider is in charge of handl
 
 ```js
 DataProvider.propTypes = {
-  baseDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  xDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
   updateInterval: PropTypes.number,
   yAccessor: PropTypes.func,
   xAccessor: PropTypes.func,

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -16,7 +16,7 @@ const randomData = () => {
   return data;
 };
 
-const _baseDomain = d3.extent(randomData(), d => d.timestamp);
+const _xDomain = d3.extent(randomData(), d => d.timestamp);
 const loader = async ({ oldSeries, reason }) => {
   if (reason === 'MOUNTED') {
     return {
@@ -42,7 +42,7 @@ class App extends Component {
         strokeWidth: 1.5,
       },
     ],
-    baseDomain: _baseDomain,
+    xDomain: _xDomain,
     zoomable: true,
   };
 
@@ -61,7 +61,7 @@ class App extends Component {
   };
 
   render() {
-    const { series, baseDomain, zoomable, dataProps, lineProps } = this.state;
+    const { series, xDomain, zoomable, dataProps, lineProps } = this.state;
     return (
       <div>
         <p>
@@ -75,7 +75,7 @@ class App extends Component {
           yAccessor={d => d.value}
           xAccessor={d => d.timestamp}
           yAxisWidth={50}
-          baseDomain={baseDomain}
+          xDomain={xDomain}
           {...dataProps}
         >
           <LineChart

--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -18,9 +18,9 @@ export default class ContextChart extends Component {
     annotations: PropTypes.arrayOf(annotationPropType),
     height: PropTypes.number.isRequired,
     contextSeries: seriesPropType,
-    baseDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
-    subDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
-    updateSubDomain: PropTypes.func.isRequired,
+    xDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+    xSubDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+    updateXSubDomain: PropTypes.func.isRequired,
     zoomable: PropTypes.bool,
     xScalerFactory: scalerFactoryFunc.isRequired,
     // Number => String
@@ -39,10 +39,10 @@ export default class ContextChart extends Component {
   };
 
   onUpdateSelection = selection => {
-    const { baseDomain, width, xScalerFactory } = this.props;
-    const xScale = xScalerFactory(baseDomain, width);
-    const subDomain = selection.map(xScale.invert).map(Number);
-    this.props.updateSubDomain(subDomain);
+    const { xDomain, width, xScalerFactory } = this.props;
+    const xScale = xScalerFactory(xDomain, width);
+    const xSubDomain = selection.map(xScale.invert).map(Number);
+    this.props.updateXSubDomain(xSubDomain);
   };
 
   getChartHeight = () => {
@@ -69,8 +69,8 @@ export default class ContextChart extends Component {
   render() {
     const {
       width,
-      baseDomain,
-      subDomain,
+      xDomain,
+      xSubDomain,
       contextSeries,
       xAxisFormatter,
       xAxisHeight,
@@ -79,8 +79,8 @@ export default class ContextChart extends Component {
       zoomable,
     } = this.props;
     const height = this.getChartHeight();
-    const xScale = xScalerFactory(baseDomain, width);
-    const selection = subDomain.map(xScale);
+    const xScale = xScalerFactory(xDomain, width);
+    const selection = xSubDomain.map(xScale);
     const annotations = this.props.annotations.map(a => (
       <Annotation key={a.id} {...a} height={height} xScale={xScale} />
     ));
@@ -89,7 +89,7 @@ export default class ContextChart extends Component {
       <XAxis
         width={width}
         height={xAxisHeight}
-        domain={baseDomain}
+        domain={xDomain}
         tickFormatter={xAxisFormatter}
         xAxisPlacement={xAxisPlacement}
         xScalerFactory={xScalerFactory}
@@ -105,7 +105,7 @@ export default class ContextChart extends Component {
             series={contextSeries}
             width={width}
             height={height}
-            domain={baseDomain}
+            domain={xDomain}
             xScalerFactory={xScalerFactory}
             scaleY={false}
           />
@@ -126,18 +126,18 @@ export default class ContextChart extends Component {
 export const ScaledContextChart = props => (
   <ScalerContext.Consumer>
     {({
-      subDomain,
-      baseDomain,
-      updateSubDomain,
+      xSubDomain,
+      xDomain,
+      updateXSubDomain,
       contextSeries,
       xScalerFactory,
     }) => (
       <ContextChart
         {...props}
-        baseDomain={baseDomain}
+        xDomain={xDomain}
         contextSeries={contextSeries}
-        subDomain={subDomain}
-        updateSubDomain={updateSubDomain}
+        xSubDomain={xSubDomain}
+        updateXSubDomain={updateXSubDomain}
         xScalerFactory={xScalerFactory}
       />
     )}

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -9,12 +9,12 @@ import GriffPropTypes, { seriesPropType } from '../../utils/proptypes';
 const calculateDomainFromData = (
   data,
   accessor,
-  y0Accessor = null,
-  y1Accessor = null
+  minAccessor = null,
+  maxAccessor = null
 ) => {
   let extent;
-  if (y0Accessor && y1Accessor) {
-    extent = [d3.min(data, y0Accessor), d3.max(data, y1Accessor)];
+  if (minAccessor && maxAccessor) {
+    extent = [d3.min(data, minAccessor), d3.max(data, maxAccessor)];
   } else {
     extent = d3.extent(data, accessor);
   }
@@ -60,11 +60,11 @@ const firstDefined = (first, ...others) => {
 
 export default class DataProvider extends Component {
   state = {
-    subDomain: DataProvider.getSubDomain(
-      this.props.baseDomain,
-      this.props.subDomain
+    xSubDomain: DataProvider.getXSubDomain(
+      this.props.xDomain,
+      this.props.xSubDomain
     ),
-    baseDomain: this.props.baseDomain,
+    xDomain: this.props.xDomain,
     loaderConfig: {},
     contextSeries: {},
     yDomains: {},
@@ -137,10 +137,10 @@ export default class DataProvider extends Component {
       return;
     }
     const { series } = this.props;
-    const { subDomain, baseDomain } = this.state;
+    const { xSubDomain, xDomain } = this.state;
 
-    if (!isEqual(this.props.subDomain, prevProps.subDomain)) {
-      this.subDomainChanged(this.props.subDomain);
+    if (!isEqual(this.props.xSubDomain, prevProps.xSubDomain)) {
+      this.xSubDomainChanged(this.props.xSubDomain);
     }
 
     const currentSeriesKeys = {};
@@ -154,24 +154,24 @@ export default class DataProvider extends Component {
     const newSeries = series.filter(s => prevSeriesKeys[s.id] !== true);
     await Promise.map(newSeries, async ({ id }) => {
       await this.fetchData(id, 'MOUNTED');
-      if (!isEqual(subDomain, baseDomain)) {
+      if (!isEqual(xSubDomain, xDomain)) {
         // The series got added when zoomed in,
         // Need to also fetch a higher-granularity version on mount
         await this.fetchData(id, 'UPDATE_SUBDOMAIN');
       }
     });
 
-    // Check if basedomain changed in props -- if so reset state.
-    if (!isEqual(this.props.baseDomain, prevProps.baseDomain)) {
-      const newSubDomain = DataProvider.getSubDomain(
-        this.props.baseDomain,
-        this.props.subDomain
+    // Check if xDomain changed in props -- if so reset state.
+    if (!isEqual(this.props.xDomain, prevProps.xDomain)) {
+      const newXSubDomain = DataProvider.getXSubDomain(
+        this.props.xDomain,
+        this.props.xSubDomain
       );
       // eslint-disable-next-line
       this.setState(
         {
-          baseDomain: this.props.baseDomain,
-          subDomain: newSubDomain,
+          xDomain: this.props.xDomain,
+          xSubDomain: newXSubDomain,
           loaderConfig: {},
           contextSeries: {},
           yDomains: {},
@@ -183,11 +183,11 @@ export default class DataProvider extends Component {
           );
         }
       );
-      if (this.props.onSubDomainChanged) {
-        this.props.onSubDomainChanged(newSubDomain);
+      if (this.props.onXSubDomainChanged) {
+        this.props.onXSubDomainChanged(newXSubDomain);
       }
-      if (this.props.onBaseDomainChanged) {
-        this.props.onBaseDomainChanged(this.props.baseDomain);
+      if (this.props.onXDomainChanged) {
+        this.props.onXDomainChanged(this.props.xDomain);
       }
       if (this.fetchInterval) {
         clearInterval(this.fetchInterval);
@@ -200,22 +200,22 @@ export default class DataProvider extends Component {
     clearInterval(this.fetchInterval);
   }
 
-  static getSubDomain = (baseDomain, subDomain) => {
-    if (!subDomain) {
-      return baseDomain;
+  static getXSubDomain = (xDomain, xSubDomain) => {
+    if (!xSubDomain) {
+      return xDomain;
     }
-    const baseDomainLength = baseDomain[1] - baseDomain[0];
-    const subDomainLength = subDomain[1] - subDomain[0];
-    if (baseDomainLength < subDomainLength) {
-      return baseDomain;
+    const xDomainLength = xDomain[1] - xDomain[0];
+    const xSubDomainLength = xSubDomain[1] - xSubDomain[0];
+    if (xDomainLength < xSubDomainLength) {
+      return xDomain;
     }
-    if (subDomain[0] < baseDomain[0]) {
-      return [baseDomain[0], baseDomain[0] + subDomainLength];
+    if (xSubDomain[0] < xDomain[0]) {
+      return [xDomain[0], xDomain[0] + xSubDomainLength];
     }
-    if (subDomain[1] > baseDomain[1]) {
-      return [baseDomain[1] - subDomainLength, baseDomain[1]];
+    if (xSubDomain[1] > xDomain[1]) {
+      return [xDomain[1] - xSubDomainLength, xDomain[1]];
     }
-    return subDomain;
+    return xSubDomain;
   };
 
   getSeriesObjects = () => {
@@ -247,14 +247,14 @@ export default class DataProvider extends Component {
     const { updateInterval } = this.props;
     if (updateInterval) {
       this.fetchInterval = setInterval(() => {
-        const { baseDomain } = this.state;
+        const { xDomain } = this.state;
         this.setState(
           {
-            baseDomain: baseDomain.map(d => d + updateInterval),
+            xDomain: xDomain.map(d => d + updateInterval),
           },
           () => {
-            if (this.props.onBaseDomainChanged) {
-              this.props.onBaseDomainChanged(this.state.baseDomain);
+            if (this.props.onXDomainChanged) {
+              this.props.onXDomainChanged(this.state.xDomain);
             }
             Promise.map(this.props.series, s =>
               this.fetchData(s.id, 'INTERVAL')
@@ -276,11 +276,13 @@ export default class DataProvider extends Component {
       y0Accessor,
       y1Accessor,
       yAccessor,
+      yDomain: propYDomain,
       ySubDomain,
     } = this.props;
     const { loaderConfig, yDomains, ySubDomains } = this.state;
     const yDomain = collection.yDomain ||
       series.yDomain ||
+      propYDomain ||
       yDomains[series.id] || [0, 0];
     return {
       drawPoints: collection.drawPoints,
@@ -345,7 +347,7 @@ export default class DataProvider extends Component {
 
   fetchData = async (id, reason) => {
     const { pointsPerSeries, defaultLoader } = this.props;
-    const { subDomain, baseDomain } = this.state;
+    const { xSubDomain, xDomain } = this.state;
     const seriesObject = this.getSingleSeriesObject(id);
     const loader = seriesObject.loader || defaultLoader;
     if (!loader) {
@@ -353,8 +355,8 @@ export default class DataProvider extends Component {
     }
     const loaderResult = await loader({
       id,
-      baseDomain,
-      subDomain,
+      xDomain,
+      xSubDomain,
       pointsPerSeries,
       oldSeries: seriesObject,
       reason,
@@ -370,6 +372,25 @@ export default class DataProvider extends Component {
     };
     const stateUpdates = {};
     if (reason === 'MOUNTED') {
+      if (!this.props.xDomain) {
+        // We were not given an xDomain, so we need to calculate one based on
+        // the loaded data.
+        const calculatedXDomain = calculateDomainFromData(
+          loaderConfig.data,
+          loaderConfig.xAccessor || this.props.xAccessor,
+          loaderConfig.x0Accessor || this.props.x0Accessor,
+          loaderConfig.x1Accessor || this.props.x1Accessor
+        );
+        // The calculated xDomain needs to be big enough to encompass all of
+        // the data, so they're all going to be merged.
+        const mergedXDomain = [
+          Math.min(calculatedXDomain[0], (xDomain || [0])[0]),
+          Math.max(calculatedXDomain[1], (xDomain || [0, 0])[1]),
+        ];
+        stateUpdates.xDomain = mergedXDomain;
+        stateUpdates.xSubDomain = mergedXDomain;
+      }
+
       const yDomain = calculateDomainFromData(
         loaderConfig.data,
         loaderConfig.yAccessor || this.props.yAccessor,
@@ -393,32 +414,32 @@ export default class DataProvider extends Component {
     this.setState(stateUpdates);
   };
 
-  subDomainChanged = subDomain => {
-    const current = this.state.subDomain;
-    if (subDomain[0] === current[0] && subDomain[1] === current[1]) {
+  xSubDomainChanged = xSubDomain => {
+    const current = this.state.xSubDomain;
+    if (xSubDomain[0] === current[0] && xSubDomain[1] === current[1]) {
       return;
     }
-    clearTimeout(this.subDomainChangedTimeout);
-    this.subDomainChangedTimeout = setTimeout(
+    clearTimeout(this.xSubDomainChangedTimeout);
+    this.xSubDomainChangedTimeout = setTimeout(
       () =>
         Promise.map(this.props.series, s =>
           this.fetchData(s.id, 'UPDATE_SUBDOMAIN')
         ),
       250
     );
-    if (this.props.onSubDomainChanged) {
-      this.props.onSubDomainChanged(subDomain);
+    if (this.props.onXSubDomainChanged) {
+      this.props.onXSubDomainChanged(xSubDomain);
     }
-    this.setState({ subDomain });
+    this.setState({ xSubDomain });
   };
 
   render() {
-    const { loaderConfig, contextSeries, baseDomain, subDomain } = this.state;
+    const { loaderConfig, contextSeries, xDomain, xSubDomain } = this.state;
     const {
       yAxisWidth,
       children,
-      baseDomain: externalBaseDomain,
-      subDomain: externalSubDomain,
+      xDomain: externalXDomain,
+      xSubDomain: externalXSubDomain,
       collections,
     } = this.props;
 
@@ -433,12 +454,12 @@ export default class DataProvider extends Component {
     const collectionDomains = seriesObjects.reduce(
       (
         acc,
-        { collectionId, yDomain: seriesDomain, ySubDomain: seriesSubDomain }
+        { collectionId, yDomain: seriesDomain, ySubDomain: seriesXSubDomain }
       ) => {
         if (!collectionId) {
           return acc;
         }
-        const { yDomain: existingDomain, ySubDomain: existingSubDomain } = acc[
+        const { yDomain: existingDomain, ySubDomain: existingXSubDomain } = acc[
           collectionId
         ] || {
           yDomain: [Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER],
@@ -452,8 +473,8 @@ export default class DataProvider extends Component {
               Math.max(existingDomain[1], seriesDomain[1]),
             ],
             ySubDomain: [
-              Math.min(existingSubDomain[0], seriesSubDomain[0]),
-              Math.max(existingSubDomain[1], seriesSubDomain[1]),
+              Math.min(existingXSubDomain[0], seriesXSubDomain[0]),
+              Math.max(existingXSubDomain[1], seriesXSubDomain[1]),
             ],
           },
         };
@@ -498,14 +519,14 @@ export default class DataProvider extends Component {
     const context = {
       series: collectedSeries,
       collections: collectionsWithDomains,
-      baseDomain,
+      xDomain,
       // This is used to signal external changes vs internal changes
-      externalBaseDomain,
-      subDomain,
+      externalXDomain,
+      xSubDomain,
       // This is used to signal external changes vs internal changes
-      externalSubDomain,
+      externalXSubDomain,
       yAxisWidth,
-      subDomainChanged: this.subDomainChanged,
+      xSubDomainChanged: this.xSubDomainChanged,
       contextSeries: seriesObjects.map(s => ({
         ...contextSeries[s.id],
         ...s,
@@ -520,23 +541,27 @@ export default class DataProvider extends Component {
 }
 
 DataProvider.propTypes = {
-  baseDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
-  subDomain: PropTypes.arrayOf(PropTypes.number),
+  xDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
+  xSubDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
   updateInterval: PropTypes.number,
+  xAccessor: PropTypes.func,
+  x0Accessor: PropTypes.func,
+  x1Accessor: PropTypes.func,
   yAccessor: PropTypes.func,
   y0Accessor: PropTypes.func,
   y1Accessor: PropTypes.func,
-  xAccessor: PropTypes.func,
   yAxisWidth: PropTypes.number,
+  yDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
   ySubDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
   pointsPerSeries: PropTypes.number,
   children: PropTypes.node.isRequired,
   defaultLoader: PropTypes.func,
   series: seriesPropType.isRequired,
   collections: GriffPropTypes.collections,
-  // (subDomain) => null
-  onSubDomainChanged: PropTypes.func,
-  onBaseDomainChanged: PropTypes.func,
+  // xSubDomain => void
+  onXSubDomainChanged: PropTypes.func,
+  // xDomain => void
+  onXDomainChanged: PropTypes.func,
   opacity: PropTypes.number,
   opacityAccessor: PropTypes.func,
   pointWidth: PropTypes.number,
@@ -547,20 +572,24 @@ DataProvider.propTypes = {
 DataProvider.defaultProps = {
   collections: [],
   defaultLoader: null,
-  onSubDomainChanged: null,
-  onBaseDomainChanged: null,
+  onXSubDomainChanged: null,
+  onXDomainChanged: null,
   opacity: 1.0,
   opacityAccessor: null,
   pointsPerSeries: 250,
   pointWidth: null,
   pointWidthAccessor: null,
   strokeWidth: null,
-  subDomain: null,
+  xDomain: null,
+  xSubDomain: null,
   updateInterval: 0,
+  x0Accessor: null,
+  x1Accessor: null,
   xAccessor: d => d.timestamp,
   y0Accessor: null,
   y1Accessor: null,
   yAccessor: d => d.value,
   yAxisWidth: 50,
+  yDomain: null,
   ySubDomain: null,
 };

--- a/src/components/GridLines/index.js
+++ b/src/components/GridLines/index.js
@@ -12,7 +12,7 @@ const propTypes = {
   height: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,
   series: seriesPropType.isRequired,
-  subDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  xSubDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
   xScalerFactory: scalerFactoryFunc,
 };
 
@@ -33,7 +33,7 @@ class GridLines extends React.Component {
       height,
       width,
       series,
-      subDomain,
+      xSubDomain,
       xScalerFactory,
     } = this.props;
 
@@ -158,7 +158,7 @@ class GridLines extends React.Component {
         }
       } else if (x.ticks !== undefined) {
         // This heavily inspired by XAxis -- maybe we can consolidate them?
-        const scale = xScalerFactory(subDomain, width);
+        const scale = xScalerFactory(xSubDomain, width);
         const values = scale.ticks(x.ticks || Math.floor(width / 100) || 1);
         values.forEach(v => {
           lines.push(
@@ -215,11 +215,11 @@ GridLines.defaultProps = defaultProps;
 
 export default props => (
   <ScalerContext.Consumer>
-    {({ series, subDomain, xScalerFactory, yTransformations }) => (
+    {({ series, xSubDomain, xScalerFactory, yTransformations }) => (
       <GridLines
         {...props}
         series={series}
-        subDomain={subDomain}
+        xSubDomain={xSubDomain}
         xScalerFactory={xScalerFactory}
         yTransformations={yTransformations}
       />

--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -52,12 +52,12 @@ const Line = ({
   }
   let circles = null;
   if (drawPoints) {
-    const subDomain = xScale.domain().map(p => p.getTime());
+    const xSubDomain = xScale.domain().map(p => p.getTime());
     circles = (
       <Points
         data={data.filter(d => {
           const x = xAccessor(d);
-          return x >= subDomain[0] && x <= subDomain[1];
+          return x >= xSubDomain[0] && x <= xSubDomain[1];
         })}
         xAccessor={xAccessor}
         yAccessor={yAccessor}

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -73,9 +73,9 @@ const propTypes = {
   onClickAnnotation: PropTypes.func,
   // event => void
   onDoubleClick: PropTypes.func,
-  // ({ subDomain, transformation }) => void
+  // ({ xSubDomain, transformation }) => void
   onZoomXAxis: PropTypes.func,
-  subDomain: PropTypes.arrayOf(PropTypes.number),
+  xSubDomain: PropTypes.arrayOf(PropTypes.number),
   xAxisHeight: PropTypes.number,
   yAxisWidth: PropTypes.number,
   contextChart: GriffPropTypes.contextChart,
@@ -138,7 +138,7 @@ const defaultProps = {
   yAxisWidth: 50,
   width: 0,
   height: 0,
-  subDomain: [],
+  xSubDomain: [],
   xAxisFormatter: multiFormat,
   xAxisPlacement: AxisPlacement.BOTTOM,
   xScalerFactory: createXScale,
@@ -268,7 +268,7 @@ class LineChartComponent extends Component {
       onMouseMove,
       pointWidth,
       size,
-      subDomain,
+      xSubDomain,
       ruler,
       width: propWidth,
       xScalerFactory,
@@ -345,7 +345,7 @@ class LineChartComponent extends Component {
         }
         xAxis={
           <XAxis
-            domain={subDomain}
+            domain={xSubDomain}
             width={chartSize.width}
             xScalerFactory={xScalerFactory}
             height={xAxisHeight}
@@ -380,12 +380,12 @@ const SizedLineChartComponent = sizeMe({ monitorHeight: true })(
 const LineChart = props => (
   <Scaler>
     <ScalerContext.Consumer>
-      {({ collections, series, subDomain, xScalerFactory, yAxisWidth }) => (
+      {({ collections, series, xSubDomain, xScalerFactory, yAxisWidth }) => (
         <SizedLineChartComponent
           {...props}
           collections={collections}
           series={series}
-          subDomain={subDomain}
+          xSubDomain={xSubDomain}
           xScalerFactory={xScalerFactory}
           yAxisWidth={yAxisWidth}
         />

--- a/src/components/LineCollection/index.js
+++ b/src/components/LineCollection/index.js
@@ -71,11 +71,11 @@ export default LineCollection;
 
 export const ScaledLineCollection = props => (
   <ScalerContext.Consumer>
-    {({ subDomain, series, xScalerFactory }) => (
+    {({ xSubDomain, series, xScalerFactory }) => (
       <LineCollection
         {...props}
         series={series}
-        domain={subDomain}
+        domain={xSubDomain}
         xScalerFactory={xScalerFactory}
       />
     )}

--- a/src/components/PointCollection/index.js
+++ b/src/components/PointCollection/index.js
@@ -39,11 +39,11 @@ export default PointCollection;
 
 export const ScaledPointCollection = props => (
   <ScalerContext.Consumer>
-    {({ subDomain, series, xScalerFactory }) => (
+    {({ xSubDomain, series, xScalerFactory }) => (
       <PointCollection
         {...props}
         series={series}
-        domain={subDomain}
+        domain={xSubDomain}
         xScalerFactory={xScalerFactory}
       />
     )}

--- a/src/components/Scatterplot/index.js
+++ b/src/components/Scatterplot/index.js
@@ -30,7 +30,7 @@ const propTypes = {
   xAxisPlacement: GriffPropTypes.axisPlacement,
   xAxisTicks: PropTypes.number,
   xScalerFactory: scalerFactoryFunc.isRequired,
-  subDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
+  xSubDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
   // Number => String
   yAxisFormatter: PropTypes.func,
   yAxisPlacement: GriffPropTypes.axisPlacement,
@@ -65,7 +65,7 @@ const ScatterplotComponent = ({
   yAxisFormatter,
   yAxisPlacement,
   yAxisTicks,
-  subDomain,
+  xSubDomain,
 }) => {
   const chartSize = {
     width,
@@ -117,7 +117,7 @@ const ScatterplotComponent = ({
       }
       xAxis={
         <XAxis
-          domain={subDomain}
+          domain={xSubDomain}
           width={chartSize.width}
           height={X_AXIS_HEIGHT}
           xScalerFactory={xScalerFactory}
@@ -141,11 +141,11 @@ const SizedScatterplotComponent = sizeMe({
 const Scatterplot = props => (
   <Scaler xScalerFactory={createLinearXScale}>
     <ScalerContext.Consumer>
-      {({ series, subDomain, xScalerFactory }) => (
+      {({ series, xSubDomain, xScalerFactory }) => (
         <SizedScatterplotComponent
           {...props}
           series={series}
-          subDomain={subDomain}
+          xSubDomain={xSubDomain}
           xScalerFactory={xScalerFactory}
         />
       )}

--- a/src/context/Data.js
+++ b/src/context/Data.js
@@ -3,7 +3,7 @@ import React from 'react';
 export default React.createContext({
   series: [],
   collections: [],
-  baseDomain: [Date.now() - 1000 * 60 * 60 * 24 * 365, 0],
+  xDomain: [Date.now() - 1000 * 60 * 60 * 24 * 365, 0],
   yAxisWidth: 50,
   contextSeries: [],
 });

--- a/src/context/Scaler.js
+++ b/src/context/Scaler.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
 export default React.createContext({
-  subDomain: [0, 0],
-  baseDomain: [0, 0],
+  xSubDomain: [0, 0],
+  xDomain: [0, 0],
   yDomains: {},
   yTransformations: {},
   series: [],

--- a/stories/GridLines.stories.js
+++ b/stories/GridLines.stories.js
@@ -4,14 +4,14 @@ import { storiesOf } from '@storybook/react';
 import { DataProvider, LineChart } from '../src';
 import { staticLoader } from './loaders';
 
-const staticBaseDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
+const staticXDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
 const CHART_HEIGHT = 500;
 
 storiesOf('Grid Lines', module)
   .add('Static horizontal lines every 35 pixels', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
       <LineChart
@@ -24,7 +24,7 @@ storiesOf('Grid Lines', module)
   .add('3 static horizontal lines', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
       <LineChart height={CHART_HEIGHT} grid={{ y: { count: 3 } }} />
@@ -33,7 +33,7 @@ storiesOf('Grid Lines', module)
   .add('Static vertical lines every 35 pixels', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
       <LineChart height={CHART_HEIGHT} grid={{ x: { pixels: 35 } }} />
@@ -42,7 +42,7 @@ storiesOf('Grid Lines', module)
   .add('3 static vertical lines', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
       <LineChart height={CHART_HEIGHT} grid={{ x: { count: 3 } }} />
@@ -51,7 +51,7 @@ storiesOf('Grid Lines', module)
   .add('Static grid lines every 75 pixels', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
       <LineChart
@@ -63,7 +63,7 @@ storiesOf('Grid Lines', module)
   .add('3 grid lines', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
       <LineChart
@@ -75,7 +75,7 @@ storiesOf('Grid Lines', module)
   .add('Dynamic horizontal lines', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
       <LineChart height={CHART_HEIGHT} grid={{ y: { seriesIds: [1] } }} />
@@ -84,7 +84,7 @@ storiesOf('Grid Lines', module)
   .add('Dynamic vertical lines', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
       <LineChart height={CHART_HEIGHT} grid={{ x: { ticks: 3 } }} />
@@ -93,7 +93,7 @@ storiesOf('Grid Lines', module)
   .add('Dynamic grid lines', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
       <LineChart
@@ -105,7 +105,7 @@ storiesOf('Grid Lines', module)
   .add('Dynamic grid lines (multiple series)', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -118,7 +118,7 @@ storiesOf('Grid Lines', module)
     <DataProvider
       key="y-dimension"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -129,7 +129,7 @@ storiesOf('Grid Lines', module)
     <DataProvider
       key="x-dimension"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -140,7 +140,7 @@ storiesOf('Grid Lines', module)
     <DataProvider
       key="grid-object"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -151,7 +151,7 @@ storiesOf('Grid Lines', module)
     <DataProvider
       key="different"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -168,7 +168,7 @@ storiesOf('Grid Lines', module)
     <DataProvider
       key="y-dimension"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} grid={{ y: { count: 5, opacity: 1 } }} />
@@ -176,7 +176,7 @@ storiesOf('Grid Lines', module)
     <DataProvider
       key="x-dimension"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} grid={{ x: { count: 5, opacity: 1 } }} />
@@ -184,7 +184,7 @@ storiesOf('Grid Lines', module)
     <DataProvider
       key="grid-object"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -195,7 +195,7 @@ storiesOf('Grid Lines', module)
     <DataProvider
       key="different"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -212,7 +212,7 @@ storiesOf('Grid Lines', module)
     <DataProvider
       key="y-dimension"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -223,7 +223,7 @@ storiesOf('Grid Lines', module)
     <DataProvider
       key="x-dimension"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -234,7 +234,7 @@ storiesOf('Grid Lines', module)
     <DataProvider
       key="grid-object"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -245,7 +245,7 @@ storiesOf('Grid Lines', module)
     <DataProvider
       key="different"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart

--- a/stories/InteractionLayer.stories.js
+++ b/stories/InteractionLayer.stories.js
@@ -7,13 +7,13 @@ import { action } from '@storybook/addon-actions';
 import { DataProvider, LineChart } from '../src';
 import { staticLoader } from './loaders';
 
-const staticBaseDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
+const staticXDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
 const CHART_HEIGHT = 500;
 
 storiesOf('InteractionLayer', module)
   .add('Ruler', () => (
     <DataProvider
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -38,7 +38,7 @@ storiesOf('InteractionLayer', module)
   .add('Area (no zoom)', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -51,24 +51,24 @@ storiesOf('InteractionLayer', module)
   ))
   .add('Area (zoom)', () => {
     class ZoomByArea extends React.Component {
-      state = { subDomain: null };
+      state = { xSubDomain: null };
 
       onAreaDefined = area => {
         const { start, end } = area;
-        const subDomain = [start.points[0].timestamp, end.points[0].timestamp];
+        const xSubDomain = [start.points[0].timestamp, end.points[0].timestamp];
         this.setState({
-          subDomain,
+          xSubDomain,
         });
-        action('New subdomain')(subDomain);
+        action('New subdomain')(xSubDomain);
       };
 
       render() {
-        const { subDomain } = this.state;
+        const { xSubDomain } = this.state;
         return (
           <DataProvider
             defaultLoader={staticLoader}
-            baseDomain={staticBaseDomain}
-            subDomain={subDomain}
+            xDomain={staticXDomain}
+            xSubDomain={xSubDomain}
             series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
           >
             <LineChart
@@ -117,7 +117,7 @@ storiesOf('InteractionLayer', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 { id: 1, color: 'steelblue' },
                 { id: 2, color: 'maroon' },
@@ -173,7 +173,7 @@ storiesOf('InteractionLayer', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 { id: 1, color: 'steelblue' },
                 { id: 2, color: 'maroon' },
@@ -218,7 +218,7 @@ storiesOf('InteractionLayer', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 { id: 1, color: 'steelblue' },
                 { id: 2, color: 'maroon' },
@@ -266,7 +266,7 @@ storiesOf('InteractionLayer', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 { id: 1, color: 'steelblue' },
                 { id: 2, color: 'maroon' },
@@ -342,7 +342,7 @@ storiesOf('InteractionLayer', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 { id: 1, color: 'steelblue' },
                 { id: 2, color: 'maroon' },
@@ -364,7 +364,7 @@ storiesOf('InteractionLayer', module)
   .add('Double-click events', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -394,7 +394,7 @@ storiesOf('InteractionLayer', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 { id: 1, color: 'steelblue' },
                 { id: 2, color: 'maroon' },

--- a/stories/LineChart.stories.js
+++ b/stories/LineChart.stories.js
@@ -15,8 +15,8 @@ import {
   liveLoader,
 } from './loaders';
 
-const staticBaseDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
-const liveBaseDomain = [Date.now() - 1000 * 30, Date.now()];
+const staticXDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
+const liveXDomain = [Date.now() - 1000 * 30, Date.now()];
 const CHART_HEIGHT = 500;
 
 /* eslint-disable react/no-multi-comp */
@@ -29,7 +29,7 @@ storiesOf('LineChart', module)
   .add('Basic', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} />
@@ -38,7 +38,7 @@ storiesOf('LineChart', module)
   .add('Custom tick formatting', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -52,7 +52,7 @@ storiesOf('LineChart', module)
     <React.Fragment>
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         series={[
           { id: 1, color: 'steelblue' },
           { id: 2, color: 'maroon' },
@@ -63,7 +63,7 @@ storiesOf('LineChart', module)
       </DataProvider>
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         series={[
           { id: 1, color: 'steelblue' },
           { id: 2, color: 'maroon' },
@@ -74,7 +74,7 @@ storiesOf('LineChart', module)
       </DataProvider>
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
       >
         <LineChart height={CHART_HEIGHT} />
@@ -84,7 +84,7 @@ storiesOf('LineChart', module)
   .add('Single-value in y axis', () => (
     <React.Fragment>
       <DataProvider
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         series={[
           { id: 1, color: 'steelblue', loader: monoLoader(0) },
           { id: 2, color: 'maroon', loader: monoLoader(0.5) },
@@ -108,7 +108,7 @@ storiesOf('LineChart', module)
       >
         <DataProvider
           defaultLoader={staticLoader}
-          baseDomain={staticBaseDomain}
+          xDomain={staticXDomain}
           series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
         >
           <LineChart />
@@ -124,7 +124,7 @@ storiesOf('LineChart', module)
       >
         <DataProvider
           defaultLoader={staticLoader}
-          baseDomain={staticBaseDomain}
+          xDomain={staticXDomain}
           series={[{ id: 2, color: 'steelblue' }, { id: 3, color: 'maroon' }]}
         >
           <LineChart contextChart={{ visible: false }} />
@@ -140,7 +140,7 @@ storiesOf('LineChart', module)
       >
         <DataProvider
           defaultLoader={staticLoader}
-          baseDomain={staticBaseDomain}
+          xDomain={staticXDomain}
           series={[{ id: 3, color: 'steelblue' }, { id: 4, color: 'maroon' }]}
         >
           <LineChart
@@ -161,7 +161,7 @@ storiesOf('LineChart', module)
       >
         <DataProvider
           defaultLoader={staticLoader}
-          baseDomain={staticBaseDomain}
+          xDomain={staticXDomain}
           series={[{ id: 3, color: 'steelblue' }, { id: 4, color: 'maroon' }]}
         >
           <LineChart xAxisHeight={25} />
@@ -173,7 +173,7 @@ storiesOf('LineChart', module)
     <div style={{ height: '100vh' }}>
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
       >
         <LineChart />
@@ -220,7 +220,7 @@ storiesOf('LineChart', module)
             >
               <DataProvider
                 defaultLoader={staticLoader}
-                baseDomain={staticBaseDomain}
+                xDomain={staticXDomain}
                 series={[
                   { id: 1, color: 'steelblue' },
                   { id: 2, color: 'maroon' },
@@ -240,7 +240,7 @@ storiesOf('LineChart', module)
       defaultLoader={customAccessorLoader}
       xAccessor={d => d[0]}
       yAccessor={d => d[1]}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} />
@@ -254,7 +254,7 @@ storiesOf('LineChart', module)
         defaultLoader={customAccessorLoader}
         xAccessor={d => d[0]}
         yAccessor={d => d[1]}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         series={[
           { id: 10, color: 'steelblue', y0Accessor, y1Accessor },
           { id: 2, color: 'maroon' },
@@ -270,7 +270,7 @@ storiesOf('LineChart', module)
     return (
       <DataProvider
         defaultLoader={customAccessorLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         xAccessor={d => d[0]}
         yAccessor={d => d[1]}
         series={[
@@ -290,7 +290,7 @@ storiesOf('LineChart', module)
         defaultLoader={customAccessorLoader}
         xAccessor={d => d[0]}
         yAccessor={d => d[1]}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         series={[
           { id: 10, color: 'steelblue', y0Accessor, y1Accessor },
           { id: 2, color: 'maroon', drawPoints: true },
@@ -303,7 +303,7 @@ storiesOf('LineChart', module)
   .add('Loading data from api', () => (
     <DataProvider
       defaultLoader={quandlLoader}
-      baseDomain={[+moment().subtract(10, 'year'), +moment()]}
+      xDomain={[+moment().subtract(10, 'year'), +moment()]}
       series={[
         {
           id: 'COM/COFFEE_BRZL',
@@ -339,7 +339,7 @@ storiesOf('LineChart', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 {
                   id: 1,
@@ -387,7 +387,7 @@ storiesOf('LineChart', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 { id: 1, color: 'steelblue', yDomain: yDomains[1] },
                 { id: 2, color: 'maroon', yDomain: yDomains[2] },
@@ -411,7 +411,7 @@ storiesOf('LineChart', module)
     const series = staticLoader({
       id: 1,
       reason: 'MOUNTED',
-      baseDomain: staticBaseDomain,
+      xDomain: staticXDomain,
     }).data;
     const exampleAnnotations = [
       {
@@ -423,7 +423,7 @@ storiesOf('LineChart', module)
     return (
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
       >
         <LineChart height={CHART_HEIGHT} annotations={exampleAnnotations} />
@@ -434,7 +434,7 @@ storiesOf('LineChart', module)
     const series = staticLoader({
       id: 1,
       reason: 'MOUNTED',
-      baseDomain: staticBaseDomain,
+      xDomain: staticXDomain,
     }).data;
     const exampleAnnotations = [
       {
@@ -446,7 +446,7 @@ storiesOf('LineChart', module)
     return (
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
       >
         <LineChart
@@ -466,7 +466,7 @@ storiesOf('LineChart', module)
     <React.Fragment>
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         pointsPerSeries={100}
         series={[
           { id: 1, color: 'steelblue' },
@@ -477,7 +477,7 @@ storiesOf('LineChart', module)
       </DataProvider>
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         pointsPerSeries={100}
         series={[
           { id: 1, color: 'steelblue' },
@@ -488,7 +488,7 @@ storiesOf('LineChart', module)
       </DataProvider>
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         pointsPerSeries={100}
         series={[
           { id: 1, color: 'steelblue' },
@@ -502,7 +502,7 @@ storiesOf('LineChart', module)
   .add('Without context chart', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} contextChart={{ visible: false }} />
@@ -531,7 +531,7 @@ storiesOf('LineChart', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 { id: 1, color: 'steelblue', zoomable: yZoomable[1] },
                 { id: 2, color: 'maroon', zoomable: yZoomable[2] },
@@ -556,30 +556,30 @@ storiesOf('LineChart', module)
     }
     return <ZoomToggle />;
   })
-  .add('Dynamic base domain', () => {
-    class DynamicBaseDomain extends React.Component {
+  .add('Dynamic x domain', () => {
+    class DynamicXDomain extends React.Component {
       state = {
-        baseDomain: staticBaseDomain,
+        xDomain: staticXDomain,
       };
 
-      toggleBaseDomain = () => {
-        const { baseDomain } = this.state;
-        const newDomain = isEqual(baseDomain, staticBaseDomain)
+      toggleXDomain = () => {
+        const { xDomain } = this.state;
+        const newDomain = isEqual(xDomain, staticXDomain)
           ? [
-              staticBaseDomain[0] - 100000000 * 50,
-              staticBaseDomain[1] + 100000000 * 50,
+              staticXDomain[0] - 100000000 * 50,
+              staticXDomain[1] + 100000000 * 50,
             ]
-          : staticBaseDomain;
-        this.setState({ baseDomain: newDomain });
+          : staticXDomain;
+        this.setState({ xDomain: newDomain });
       };
 
       render() {
-        const { baseDomain } = this.state;
+        const { xDomain } = this.state;
         return (
           <div>
-            <button onClick={this.toggleBaseDomain}>
-              {isEqual(baseDomain, staticBaseDomain)
-                ? 'Shrink baseDomain'
+            <button onClick={this.toggleXDomain}>
+              {isEqual(xDomain, staticXDomain)
+                ? 'Shrink xDomain'
                 : 'Reset base domain'}
             </button>
             <DataProvider
@@ -588,8 +588,8 @@ storiesOf('LineChart', module)
                 { id: 1, color: 'steelblue' },
                 { id: 2, color: 'maroon' },
               ]}
-              baseDomain={baseDomain}
-              onBaseDomainChanged={action('base domain changed')}
+              xDomain={xDomain}
+              onXDomainChanged={action('base domain changed')}
             >
               <LineChart height={CHART_HEIGHT} />
             </DataProvider>
@@ -597,14 +597,14 @@ storiesOf('LineChart', module)
         );
       }
     }
-    return <DynamicBaseDomain />;
+    return <DynamicXDomain />;
   })
   .add('ySubDomain', () => (
     <React.Fragment>
       <h1>Set on DataProvider</h1>
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         ySubDomain={[0.25, 0.5]}
         series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
       >
@@ -613,7 +613,7 @@ storiesOf('LineChart', module)
       <h1>Set on Series</h1>
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         series={[
           { id: 3, color: 'steelblue', ySubDomain: [0.25, 0.5] },
           { id: 4, color: 'maroon' },
@@ -624,7 +624,7 @@ storiesOf('LineChart', module)
       <h1>Set on Collection</h1>
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         collections={[{ id: 'all', color: 'green', ySubDomain: [0.0, 0.5] }]}
         series={[
           {
@@ -645,7 +645,7 @@ storiesOf('LineChart', module)
       </p>
       <DataProvider
         defaultLoader={staticLoader}
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         series={[
           {
             id: 3,
@@ -660,15 +660,18 @@ storiesOf('LineChart', module)
       </DataProvider>
     </React.Fragment>
   ))
-  .add('Dynamic sub domain', () => {
-    const subDomainFirst = [
+  .add('Dynamic x sub domain', () => {
+    const xSubDomainFirst = [
       Date.now() - 1000 * 60 * 60 * 24 * 20,
       Date.now() - 1000 * 60 * 60 * 24 * 10,
     ];
 
-    const subDomainSecond = [Date.now() - 1000 * 60 * 60 * 24 * 10, Date.now()];
+    const xSubDomainSecond = [
+      Date.now() - 1000 * 60 * 60 * 24 * 10,
+      Date.now(),
+    ];
 
-    class CustomSubDomain extends React.Component {
+    class CustomXSubDomain extends React.Component {
       state = {
         isFirst: true,
       };
@@ -680,13 +683,15 @@ storiesOf('LineChart', module)
               onClick={() => this.setState({ isFirst: !this.state.isFirst })}
             >
               {this.state.isFirst
-                ? `Switch subDomain`
-                : `Switch back subDomain`}
+                ? `Switch xSubDomain`
+                : `Switch back xSubDomain`}
             </button>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
-              subDomain={this.state.isFirst ? subDomainFirst : subDomainSecond}
+              xDomain={staticXDomain}
+              xSubDomain={
+                this.state.isFirst ? xSubDomainFirst : xSubDomainSecond
+              }
               series={[
                 { id: 1, color: 'steelblue' },
                 { id: 2, color: 'maroon' },
@@ -698,12 +703,12 @@ storiesOf('LineChart', module)
         );
       }
     }
-    return <CustomSubDomain />;
+    return <CustomXSubDomain />;
   })
   .add('Live loading', () => (
     <DataProvider
       defaultLoader={liveLoader}
-      baseDomain={liveBaseDomain}
+      xDomain={liveXDomain}
       updateInterval={33}
       yAxisWidth={50}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
@@ -714,7 +719,7 @@ storiesOf('LineChart', module)
   .add('Live loading and ruler', () => (
     <DataProvider
       defaultLoader={liveLoader}
-      baseDomain={liveBaseDomain}
+      xDomain={liveXDomain}
       updateInterval={33}
       yAxisWidth={50}
       series={[
@@ -745,7 +750,7 @@ storiesOf('LineChart', module)
       { value: 'COM/COFFEE_CLMB', label: 'Columbia coffe price' },
     ];
 
-    const baseDomain = [+moment().subtract(10, 'year'), +moment()];
+    const xDomain = [+moment().subtract(10, 'year'), +moment()];
 
     // eslint-disable-next-line
     class EnableDisableSeries extends React.Component {
@@ -769,7 +774,7 @@ storiesOf('LineChart', module)
             <DataProvider
               defaultLoader={quandlLoader}
               pointsPerSeries={100}
-              baseDomain={baseDomain}
+              xDomain={xDomain}
               series={series.map(s => ({
                 id: s.value,
                 color: colors[s.value],

--- a/stories/Scatterplot.stories.js
+++ b/stories/Scatterplot.stories.js
@@ -30,6 +30,7 @@ const scatterplotloader = ({ id, reason, oldSeries, ...params }) => {
         reason,
         oldSeries,
         ...params,
+        xDomain: [0, 1],
       }),
       y: staticLoader({
         id: pair.y,
@@ -37,6 +38,7 @@ const scatterplotloader = ({ id, reason, oldSeries, ...params }) => {
         reason,
         oldSeries,
         ...params,
+        xDomain: [0, 1],
       }),
     };
 
@@ -86,7 +88,7 @@ storiesOf('Scatterplot', module)
         <div style={{ height: '500px', width: '100%' }}>
           <DataProvider
             defaultLoader={scatterplotloader}
-            baseDomain={[0, 1]}
+            xDomain={[0, 1]}
             series={[{ id: '1 2', color: 'steelblue' }]}
             xAccessor={d => +d.x}
             yAccessor={d => +d.y}
@@ -100,7 +102,7 @@ storiesOf('Scatterplot', module)
         <div style={{ height: '500px', width: '100%' }}>
           <DataProvider
             defaultLoader={scatterplotloader}
-            baseDomain={[0, 1]}
+            xDomain={[0, 1]}
             series={[
               { id: 'sincos', color: '#ACF39D' },
               { id: 'sintan', color: '#E85F5C' },
@@ -118,7 +120,7 @@ storiesOf('Scatterplot', module)
         <div style={{ height: '500px', width: '100%' }}>
           <DataProvider
             defaultLoader={scatterplotloader}
-            baseDomain={[0, 1]}
+            xDomain={[0, 1]}
             series={[
               { id: '1 2', color: '#ACF39D' },
               { id: '2 3', color: '#E85F5C' },
@@ -138,12 +140,87 @@ storiesOf('Scatterplot', module)
       </div>
     </React.Fragment>
   ))
+  .add('Domains', () => (
+    <React.Fragment>
+      <div>
+        <h3>Specified domains</h3>
+        <div style={{ height: '500px', width: '100%' }}>
+          <DataProvider
+            defaultLoader={scatterplotloader}
+            xDomain={[-1, 2]}
+            yDomain={[-1, 2]}
+            series={[{ id: '1 2', color: 'steelblue' }]}
+            xAccessor={d => +d.x}
+            yAccessor={d => +d.y}
+          >
+            <Scatterplot zoomable />
+          </DataProvider>
+        </div>
+      </div>
+      <div>
+        <h3>Specified x domain</h3>
+        <div style={{ height: '500px', width: '100%' }}>
+          <DataProvider
+            defaultLoader={scatterplotloader}
+            xDomain={[-1, 2]}
+            series={[{ id: '1 2', color: 'steelblue' }]}
+            xAccessor={d => +d.x}
+            yAccessor={d => +d.y}
+          >
+            <Scatterplot zoomable />
+          </DataProvider>
+        </div>
+      </div>
+      <div>
+        <h3>Specified y domain</h3>
+        <div style={{ height: '500px', width: '100%' }}>
+          <DataProvider
+            defaultLoader={scatterplotloader}
+            yDomain={[-1, 2]}
+            series={[{ id: '1 2', color: 'steelblue' }]}
+            xAccessor={d => +d.x}
+            yAccessor={d => +d.y}
+          >
+            <Scatterplot zoomable />
+          </DataProvider>
+        </div>
+      </div>
+      <div>
+        <h3>Calculated domains</h3>
+        <div style={{ height: '500px', width: '100%' }}>
+          <DataProvider
+            defaultLoader={scatterplotloader}
+            series={[{ id: '1 2', color: 'steelblue' }]}
+            xAccessor={d => +d.x}
+            yAccessor={d => +d.y}
+          >
+            <Scatterplot zoomable />
+          </DataProvider>
+        </div>
+      </div>
+      <div>
+        <h3>Smaller domains</h3>
+        <div style={{ height: '500px', width: '100%' }}>
+          <DataProvider
+            defaultLoader={scatterplotloader}
+            xDomain={[0.25, 0.75]}
+            yDomain={[0.25, 0.75]}
+            series={[{ id: '1 2', color: 'steelblue' }]}
+            xAccessor={d => +d.x}
+            yAccessor={d => +d.y}
+          >
+            <Scatterplot zoomable />
+          </DataProvider>
+        </div>
+      </div>
+    </React.Fragment>
+  ))
   .add('Custom tick formatting', () => (
     <React.Fragment>
       <div style={{ height: '500px', width: '100%' }}>
         <DataProvider
           defaultLoader={scatterplotloader}
-          baseDomain={[0, 1]}
+          xDomain={[0, 1]}
           series={[{ id: '1 2', color: 'steelblue' }]}
           xAccessor={d => +d.x}
           yAccessor={d => +d.y}
@@ -161,7 +238,7 @@ storiesOf('Scatterplot', module)
     <div style={{ height: '500px', width: '500px' }}>
       <DataProvider
         defaultLoader={scatterplotloader}
-        baseDomain={[0, 1]}
+        xDomain={[0, 1]}
         series={[{ id: '1 2', color: 'steelblue' }]}
         xAccessor={d => +d.x}
         yAccessor={d => +d.y}
@@ -190,7 +267,7 @@ storiesOf('Scatterplot', module)
           >
             <DataProvider
               defaultLoader={scatterplotloader}
-              baseDomain={[0, 1]}
+              xDomain={[0, 1]}
               series={[{ id: '1 2', color: 'steelblue' }]}
               xAccessor={d => +d.x}
               yAccessor={d => +d.y}
@@ -213,7 +290,7 @@ storiesOf('Scatterplot', module)
           >
             <DataProvider
               defaultLoader={scatterplotloader}
-              baseDomain={[0, 1]}
+              xDomain={[0, 1]}
               series={[{ id: '1 2', color: 'steelblue' }]}
               xAccessor={d => +d.x}
               yAccessor={d => +d.y}
@@ -233,7 +310,7 @@ storiesOf('Scatterplot', module)
       >
         <DataProvider
           defaultLoader={scatterplotloader}
-          baseDomain={[0, 1]}
+          xDomain={[0, 1]}
           series={[{ id: '1 2', color: 'steelblue' }]}
           xAccessor={d => +d.x}
           yAccessor={d => +d.y}
@@ -252,7 +329,7 @@ storiesOf('Scatterplot', module)
       <div style={{ height: '500px', width: '500px' }}>
         <DataProvider
           defaultLoader={scatterplotloader}
-          baseDomain={[0, 1]}
+          xDomain={[0, 1]}
           series={[
             { id: '1 2', color: 'steelblue', strokeWidth: 2 },
             { id: '3 4', color: 'maroon', strokeWidth: 10 },
@@ -266,7 +343,7 @@ storiesOf('Scatterplot', module)
       <div style={{ height: '500px', width: '500px' }}>
         <DataProvider
           defaultLoader={scatterplotloader}
-          baseDomain={[0, 1]}
+          xDomain={[0, 1]}
           series={[
             { id: '1 2', color: 'steelblue' },
             { id: '3 4', color: 'maroon' },
@@ -285,7 +362,7 @@ storiesOf('Scatterplot', module)
       <div style={{ height: '500px', width: '500px' }}>
         <DataProvider
           defaultLoader={scatterplotloader}
-          baseDomain={[0, 1]}
+          xDomain={[0, 1]}
           series={[
             { id: '1 2', color: 'steelblue', pointWidth: 2 },
             { id: '3 4', color: 'maroon', pointWidth: 10 },
@@ -299,7 +376,7 @@ storiesOf('Scatterplot', module)
       <div style={{ height: '500px', width: '500px' }}>
         <DataProvider
           defaultLoader={scatterplotloader}
-          baseDomain={[0, 1]}
+          xDomain={[0, 1]}
           series={[
             { id: '1 2', color: 'steelblue' },
             { id: '3 4', color: 'maroon' },
@@ -314,7 +391,7 @@ storiesOf('Scatterplot', module)
       <div style={{ height: '500px', width: '500px' }}>
         <DataProvider
           defaultLoader={scatterplotloader}
-          baseDomain={[0, 1]}
+          xDomain={[0, 1]}
           series={[
             { id: '1 2', color: 'steelblue' },
             { id: '3 4', color: 'maroon' },
@@ -333,7 +410,7 @@ storiesOf('Scatterplot', module)
       <div style={{ height: '500px', width: '500px' }}>
         <DataProvider
           defaultLoader={scatterplotloader}
-          baseDomain={[0, 1]}
+          xDomain={[0, 1]}
           series={[
             { id: '1 2', color: 'steelblue', opacity: 0.25 },
             { id: '3 4', color: 'maroon', opacity: 0.75 },
@@ -348,7 +425,7 @@ storiesOf('Scatterplot', module)
       <div style={{ height: '500px', width: '500px' }}>
         <DataProvider
           defaultLoader={scatterplotloader}
-          baseDomain={[0, 1]}
+          xDomain={[0, 1]}
           series={[
             { id: '1 2', color: 'steelblue' },
             { id: '3 4', color: 'maroon' },

--- a/stories/SeriesCollections.stories.js
+++ b/stories/SeriesCollections.stories.js
@@ -4,14 +4,14 @@ import { storiesOf } from '@storybook/react';
 import { AxisDisplayMode, DataProvider, LineChart } from '../src';
 import { staticLoader } from './loaders';
 
-const staticBaseDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
+const staticXDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
 const CHART_HEIGHT = 500;
 
 storiesOf('Series Collections', module)
   .add('Single collection', () => [
     <DataProvider
       key="simple"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -25,7 +25,7 @@ storiesOf('Series Collections', module)
     </DataProvider>,
     <DataProvider
       key="scaled"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -46,7 +46,7 @@ storiesOf('Series Collections', module)
   ])
   .add('Multiple collections', () => (
     <DataProvider
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -63,7 +63,7 @@ storiesOf('Series Collections', module)
   ))
   .add('Mixed items', () => (
     <DataProvider
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -80,7 +80,7 @@ storiesOf('Series Collections', module)
   .add('drawPoints', () => [
     <DataProvider
       key="default"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -94,7 +94,7 @@ storiesOf('Series Collections', module)
     </DataProvider>,
     <DataProvider
       key="override"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -116,7 +116,7 @@ storiesOf('Series Collections', module)
   .add('hidden', () => [
     <DataProvider
       key="default"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -130,7 +130,7 @@ storiesOf('Series Collections', module)
     </DataProvider>,
     <DataProvider
       key="preference"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -150,7 +150,7 @@ storiesOf('Series Collections', module)
     </DataProvider>,
     <DataProvider
       key="override"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -172,7 +172,7 @@ storiesOf('Series Collections', module)
   .add('strokeWidth', () => [
     <DataProvider
       key="default"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -186,7 +186,7 @@ storiesOf('Series Collections', module)
     </DataProvider>,
     <DataProvider
       key="preference"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -206,7 +206,7 @@ storiesOf('Series Collections', module)
     </DataProvider>,
     <DataProvider
       key="override"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -231,7 +231,7 @@ storiesOf('Series Collections', module)
     return [
       <DataProvider
         key="default"
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         defaultLoader={staticLoader}
         xAccessor={d => d.timestamp}
         yAccessor={d => d.value}
@@ -250,7 +250,7 @@ storiesOf('Series Collections', module)
       </DataProvider>,
       <DataProvider
         key="preference"
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         defaultLoader={staticLoader}
         xAccessor={d => d.timestamp}
         yAccessor={d => d.value}
@@ -271,7 +271,7 @@ storiesOf('Series Collections', module)
       </DataProvider>,
       <DataProvider
         key="override"
-        baseDomain={staticBaseDomain}
+        xDomain={staticXDomain}
         defaultLoader={staticLoader}
         xAccessor={d => d.timestamp}
         yAccessor={d => d.value}
@@ -295,7 +295,7 @@ storiesOf('Series Collections', module)
   .add('yAxisDisplayMode', () => [
     <DataProvider
       key="default"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -311,7 +311,7 @@ storiesOf('Series Collections', module)
     </DataProvider>,
     <DataProvider
       key="override"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -337,7 +337,7 @@ storiesOf('Series Collections', module)
     // yDomain.
     <DataProvider
       key="default"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -353,7 +353,7 @@ storiesOf('Series Collections', module)
     // ignored because it is ignored when in a collection.
     <DataProvider
       key="override"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}
@@ -376,7 +376,7 @@ storiesOf('Series Collections', module)
     // yDomain as the collection.
     <DataProvider
       key="scaled"
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       defaultLoader={staticLoader}
       xAccessor={d => d.timestamp}
       yAccessor={d => d.value}

--- a/stories/StaticAxis.js
+++ b/stories/StaticAxis.js
@@ -26,7 +26,7 @@ const baseConfig = {
     accessor: d => d.timestamp,
     calculateDomain: data => d3.extent(d => d.timestamp),
   },
-  baseDomain: d3.extent(randomData(), d => d.timestamp),
+  xDomain: d3.extent(randomData(), d => d.timestamp),
 };
 
 const loader = () => {

--- a/stories/XAxisPlacements.stories.js
+++ b/stories/XAxisPlacements.stories.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react';
 import { DataProvider, LineChart, AxisPlacement } from '../src';
 import { staticLoader } from './loaders';
 
-const staticBaseDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
+const staticXDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
 const CHART_HEIGHT = 500;
 
 storiesOf('X-Axis Placement', module)
@@ -12,7 +12,7 @@ storiesOf('X-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} />
@@ -20,7 +20,7 @@ storiesOf('X-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', collectionId: '1+2' },
         { id: 2, color: 'maroon', collectionId: '1+2' },
@@ -34,7 +34,7 @@ storiesOf('X-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} xAxisPlacement={AxisPlacement.TOP} />
@@ -42,7 +42,7 @@ storiesOf('X-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', collectionId: '1+2' },
         { id: 2, color: 'maroon', collectionId: '1+2' },
@@ -56,7 +56,7 @@ storiesOf('X-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} xAxisPlacement={AxisPlacement.BOTTOM} />
@@ -64,7 +64,7 @@ storiesOf('X-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', collectionId: '1+2' },
         { id: 2, color: 'maroon', collectionId: '1+2' },
@@ -78,7 +78,7 @@ storiesOf('X-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} xAxisPlacement={AxisPlacement.BOTH} />
@@ -86,7 +86,7 @@ storiesOf('X-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', collectionId: '1+2' },
         { id: 2, color: 'maroon', collectionId: '1+2' },

--- a/stories/YAxisModes.stories.js
+++ b/stories/YAxisModes.stories.js
@@ -5,7 +5,7 @@ import { action } from '@storybook/addon-actions';
 import { DataProvider, LineChart, AxisDisplayMode } from '../src';
 import { staticLoader } from './loaders';
 
-const staticBaseDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
+const staticXDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
 const CHART_HEIGHT = 500;
 
 storiesOf('Y-Axis Modes', module)
@@ -31,7 +31,7 @@ storiesOf('Y-Axis Modes', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={series}
             >
               <LineChart
@@ -50,7 +50,7 @@ storiesOf('Y-Axis Modes', module)
   .add('Without y axis', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -62,7 +62,7 @@ storiesOf('Y-Axis Modes', module)
   .add('Collapsed y axis', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart
@@ -74,7 +74,7 @@ storiesOf('Y-Axis Modes', module)
   .add('Collapsed collection', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       collections={[{ id: 'all', color: 'deepred' }]}
       series={[
         { id: 1, collectionId: 'all', color: 'steelblue' },
@@ -90,7 +90,7 @@ storiesOf('Y-Axis Modes', module)
   .add('Collapsed collected series', () => (
     <DataProvider
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       collections={[{ id: 'all', color: 'deepred' }]}
       series={[
         {
@@ -121,7 +121,7 @@ storiesOf('Y-Axis Modes', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 {
                   id: 1,
@@ -188,7 +188,7 @@ storiesOf('Y-Axis Modes', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 {
                   id: 1,
@@ -272,7 +272,7 @@ storiesOf('Y-Axis Modes', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={series}
             >
               <LineChart
@@ -372,7 +372,7 @@ storiesOf('Y-Axis Modes', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               collections={collections}
               series={series}
             >
@@ -402,7 +402,7 @@ storiesOf('Y-Axis Modes', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 { id: 1, color: 'steelblue' },
                 { id: 2, color: 'maroon' },
@@ -476,7 +476,7 @@ storiesOf('Y-Axis Modes', module)
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
-              baseDomain={staticBaseDomain}
+              xDomain={staticXDomain}
               series={[
                 { id: 1, color: 'steelblue' },
                 { id: 2, color: 'maroon' },

--- a/stories/YAxisPlacements.stories.js
+++ b/stories/YAxisPlacements.stories.js
@@ -9,7 +9,7 @@ import {
 } from '../src';
 import { staticLoader } from './loaders';
 
-const staticBaseDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
+const staticXDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
 const CHART_HEIGHT = 500;
 
 storiesOf('Y-Axis Placement', module)
@@ -17,7 +17,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} />
@@ -25,7 +25,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', collectionId: '1+2' },
         { id: 2, color: 'maroon', collectionId: '1+2' },
@@ -39,7 +39,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.LEFT} />
@@ -47,7 +47,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', collectionId: '1+2' },
         { id: 2, color: 'maroon', collectionId: '1+2' },
@@ -61,7 +61,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.RIGHT} />
@@ -69,7 +69,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', collectionId: '1+2' },
         { id: 2, color: 'maroon', collectionId: '1+2' },
@@ -83,7 +83,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
       <LineChart height={CHART_HEIGHT} yAxisPlacement={AxisPlacement.BOTH} />
@@ -91,7 +91,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', collectionId: '1+2' },
         { id: 2, color: 'maroon', collectionId: '1+2' },
@@ -105,7 +105,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', yAxisPlacement: AxisPlacement.LEFT },
         { id: 2, color: 'maroon', yAxisPlacement: AxisPlacement.RIGHT },
@@ -116,7 +116,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         {
           id: 1,
@@ -143,7 +143,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', yAxisPlacement: AxisPlacement.LEFT },
         { id: 2, color: 'maroon', yAxisPlacement: AxisPlacement.RIGHT },
@@ -155,7 +155,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         {
           id: 1,
@@ -189,7 +189,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', yAxisPlacement: AxisPlacement.LEFT },
         { id: 2, color: 'maroon', yAxisPlacement: AxisPlacement.RIGHT },
@@ -201,7 +201,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         {
           id: 1,
@@ -235,7 +235,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', yAxisPlacement: AxisPlacement.LEFT },
         { id: 2, color: 'maroon', yAxisPlacement: AxisPlacement.LEFT },
@@ -246,7 +246,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         {
           id: 1,
@@ -270,7 +270,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         { id: 1, color: 'steelblue', yAxisPlacement: AxisPlacement.LEFT },
         { id: 2, color: 'maroon' },
@@ -283,7 +283,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         {
           id: 1,
@@ -298,7 +298,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         {
           id: 1,
@@ -326,7 +326,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="series"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         {
           id: 1,
@@ -342,7 +342,7 @@ storiesOf('Y-Axis Placement', module)
     <DataProvider
       key="collections"
       defaultLoader={staticLoader}
-      baseDomain={staticBaseDomain}
+      xDomain={staticXDomain}
       series={[
         {
           id: 1,

--- a/stories/loaders.js
+++ b/stories/loaders.js
@@ -2,14 +2,14 @@ import 'react-select/dist/react-select.css';
 import { action } from '@storybook/addon-actions';
 
 const randomData = ({
-  baseDomain,
+  xDomain,
   n = 250,
   singleValue = undefined,
   func = Math.random,
 }) => {
   const data = [];
-  const dt = (baseDomain[1] - baseDomain[0]) / n;
-  for (let i = baseDomain[0]; i <= baseDomain[1]; i += dt) {
+  const dt = (xDomain[1] - xDomain[0]) / n;
+  for (let i = xDomain[0]; i <= xDomain[1]; i += dt) {
     const value = singleValue === undefined ? func(i) : singleValue;
     data.push({
       timestamp: i,
@@ -19,14 +19,10 @@ const randomData = ({
   return data;
 };
 
-export const monoLoader = singleValue => ({
-  baseDomain,
-  oldSeries,
-  reason,
-}) => {
+export const monoLoader = singleValue => ({ xDomain, oldSeries, reason }) => {
   if (reason === 'MOUNTED') {
     return {
-      data: randomData({ baseDomain, singleValue }),
+      data: randomData({ xDomain, singleValue }),
     };
   }
   return {
@@ -36,7 +32,7 @@ export const monoLoader = singleValue => ({
 
 export const staticLoader = ({
   id,
-  baseDomain,
+  xDomain,
   n = 250,
   multiplier = 1,
   oldSeries,
@@ -47,7 +43,7 @@ export const staticLoader = ({
     // Create dataset on mount
     const func = typeof id === 'function' ? id : Math.random;
     return {
-      data: randomData({ func, baseDomain, n, multiplier }),
+      data: randomData({ func, xDomain, n, multiplier }),
     };
   }
   // Otherwise, return the existing dataset.
@@ -56,18 +52,18 @@ export const staticLoader = ({
   };
 };
 
-export const liveLoader = ({ oldSeries, baseDomain, reason }) => {
+export const liveLoader = ({ oldSeries, xDomain, reason }) => {
   // action('LOADER_REQUEST_DATA')(id, reason);
   if (reason === 'MOUNTED') {
     // Create dataset on mount
     return {
-      data: randomData({ baseDomain, n: 25 }),
+      data: randomData({ xDomain, n: 25 }),
     };
   }
   if (reason === 'INTERVAL') {
     let splicingIndex = 0;
     for (let i = 0; i < oldSeries.data; i += 1) {
-      if (oldSeries.data[i] >= baseDomain[0]) {
+      if (oldSeries.data[i] >= xDomain[0]) {
         splicingIndex = i - 1;
         break;
       }
@@ -87,10 +83,10 @@ export const liveLoader = ({ oldSeries, baseDomain, reason }) => {
   };
 };
 
-export const customAccessorLoader = ({ baseDomain, oldSeries, reason }) => {
+export const customAccessorLoader = ({ xDomain, oldSeries, reason }) => {
   if (reason === 'MOUNTED') {
     return {
-      data: randomData({ baseDomain }).map(d => [d.timestamp, d.value]),
+      data: randomData({ xDomain }).map(d => [d.timestamp, d.value]),
     };
   }
   return {

--- a/stories/quandlLoader.js
+++ b/stories/quandlLoader.js
@@ -23,20 +23,20 @@ const formatDate = date => moment(date).format('YYYY-MM-DD');
 
 export default async ({
   id,
-  baseDomain,
-  subDomain,
+  xDomain,
+  xSubDomain,
   pointsPerSeries,
   oldSeries,
   reason,
 }) => {
-  const granularity = calculateGranularity(subDomain, pointsPerSeries);
+  const granularity = calculateGranularity(xSubDomain, pointsPerSeries);
   action(`Loader requested data for id ${id}. Reason: ${reason}`)(
     reason,
-    baseDomain,
-    subDomain,
+    xDomain,
+    xSubDomain,
     granularity
   );
-  const domain = reason === 'MOUNTED' ? baseDomain : subDomain;
+  const domain = reason === 'MOUNTED' ? xDomain : xSubDomain;
   const result = await axios.get(
     `https://www.quandl.com/api/v3/datasets/${id}.json?start_date=${formatDate(
       domain[0]

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -1,36 +1,36 @@
 import expect from 'expect';
 import { DataProvider } from 'src/';
 
-const { getSubDomain } = DataProvider;
+const { getXSubDomain } = DataProvider;
 
-describe('getSubDomain', () => {
+describe('getXSubDomain', () => {
   it('handles the base case', () => {
-    const baseDomain = [0, 100];
-    const subDomain = [25, 75];
-    expect(getSubDomain(baseDomain, subDomain)).toMatch(subDomain);
+    const xDomain = [0, 100];
+    const xSubDomain = [25, 75];
+    expect(getXSubDomain(xDomain, xSubDomain)).toMatch(xSubDomain);
   });
 
   it('handles when the subdomain goes longer', () => {
-    const baseDomain = [50, 100];
-    const subDomain = [95, 105];
-    expect(getSubDomain(baseDomain, subDomain)).toMatch([90, 100]);
+    const xDomain = [50, 100];
+    const xSubDomain = [95, 105];
+    expect(getXSubDomain(xDomain, xSubDomain)).toMatch([90, 100]);
   });
 
   it('handles when the subdomain goes shorter', () => {
-    const baseDomain = [50, 100];
-    const subDomain = [45, 55];
-    expect(getSubDomain(baseDomain, subDomain)).toMatch([50, 60]);
+    const xDomain = [50, 100];
+    const xSubDomain = [45, 55];
+    expect(getXSubDomain(xDomain, xSubDomain)).toMatch([50, 60]);
   });
 
   it('handles when the subdomain is outside', () => {
-    const baseDomain = [50, 100];
-    const subDomain = [150, 160];
-    expect(getSubDomain(baseDomain, subDomain)).toMatch([90, 100]);
+    const xDomain = [50, 100];
+    const xSubDomain = [150, 160];
+    expect(getXSubDomain(xDomain, xSubDomain)).toMatch([90, 100]);
   });
 
   it('handles when the subdomain is longer than the domain', () => {
-    const baseDomain = [50, 100];
-    const subDomain = [25, 125];
-    expect(getSubDomain(baseDomain, subDomain)).toMatch([50, 100]);
+    const xDomain = [50, 100];
+    const xSubDomain = [25, 125];
+    expect(getXSubDomain(xDomain, xSubDomain)).toMatch([50, 100]);
   });
 });


### PR DESCRIPTION
Instead of using a notion of baseDomain and subDomain, introduce a
xDomain and xSubDomain. These mirror the yDomain and ySubDomain
properties. This change is necessary because, with the addition of
scatterplots, not all charted data has a relevant time property.

This will also let the X values be populated by the extent of the data,
similar to the yDomain is calculated by the range of the data.

The xDomain is still passed into the loader so that it can do the right
thing -- for time-based loaders, the xDomain will continue to represent
time. However, for loaders which have time as an independent axis, they
can manage their own notion of which data to load.