### PR TITLE
Correctly bump the prerelease when bumping

### DIFF
--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -43,7 +43,10 @@ function findVersionToBump(currentVersion, versions) {
     .sort((a, b) => semver.patch(b) - semver.patch(a))
     .sort((a, b) => {
       if (semver.prerelease(b) && semver.prerelease(a)) {
-        return Number(semver.prerelease(b)) - Number(semver.prerelease(a));
+        return (
+          Number(semver.prerelease(b).pop()) -
+          Number(semver.prerelease(a).pop())
+        );
       }
       return Number(semver.patch(b)) - Number(semver.patch(b));
     });

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -42,10 +42,11 @@ function findVersionToBump(currentVersion, versions) {
     .filter(v => !!semver.prerelease(v) === !!current.prerelease)
     .sort((a, b) => semver.patch(b) - semver.patch(a))
     .sort((a, b) => {
-      if (semver.prerelease(b) && semver.prerelease(a)) {
+      const first = semver.prerelease(a);
+      const second = semver.prerelease(b);
+      if (first && second) {
         return (
-          Number(semver.prerelease(b).pop()) -
-          Number(semver.prerelease(a).pop())
+          Number(second[second.length - 1]) - Number(first[first.length - 1])
         );
       }
       return Number(semver.patch(b)) - Number(semver.patch(b));


### PR DESCRIPTION
When publishing the prerelease, if it's a named prerelease, the returned
object will be `[ 'name', 2 ]` -- we need to extract the correct value.