### PR TITLE
Add sub domain control props to DataProvider

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -244,13 +244,13 @@ export default class DataProvider extends Component {
     const { updateInterval } = this.props;
     if (updateInterval) {
       this.fetchInterval = setInterval(() => {
-        const { baseDomain, subDomain } = this.state;
+        const { xDomain, xSubDomain } = this.state;
         this.setState(
           {
-            baseDomain: baseDomain.map(d => d + updateInterval),
-            subDomain: this.props.isSubDomainSticky
-              ? subDomain.map(d => d + updateInterval)
-              : subDomain,
+            xDomain: xDomain.map(d => d + updateInterval),
+            xSubDomain: this.props.isXSubDomainSticky
+              ? xSubDomain.map(d => d + updateInterval)
+              : xSubDomain,
           },
           () => {
             Promise.map(this.props.series, s =>
@@ -390,18 +390,18 @@ export default class DataProvider extends Component {
     this.setState(stateUpdates);
   };
 
-  subDomainChanged = subDomain => {
-    const current = this.state.subDomain;
-    const newSubDomain = this.props.limitSubDomain
-      ? this.props.limitSubDomain(subDomain)
-      : subDomain;
+  xSubDomainChanged = xSubDomain => {
+    const current = this.state.xSubDomain;
+    const newXSubDomain = this.props.limitXSubDomain
+      ? this.props.limitXSubDomain(xSubDomain)
+      : xSubDomain;
 
-    if (newSubDomain[0] === current[0] && newSubDomain[1] === current[1]) {
+    if (newXSubDomain[0] === current[0] && newXSubDomain[1] === current[1]) {
       return;
     }
 
-    clearTimeout(this.subDomainChangedTimeout);
-    this.subDomainChangedTimeout = setTimeout(
+    clearTimeout(this.xSubDomainChangedTimeout);
+    this.xSubDomainChangedTimeout = setTimeout(
       () =>
         Promise.map(this.props.series, s =>
           this.fetchData(s.id, 'UPDATE_SUBDOMAIN')
@@ -409,10 +409,10 @@ export default class DataProvider extends Component {
       250
     );
 
-    if (this.props.onSubDomainChanged) {
-      this.props.onSubDomainChanged(newSubDomain);
+    if (this.props.onXSubDomainChanged) {
+      this.props.onXSubDomainChanged(newXSubDomain);
     }
-    this.setState({ subDomain: newSubDomain });
+    this.setState({ xSubDomain: newXSubDomain });
   };
 
   render() {
@@ -544,8 +544,8 @@ DataProvider.propTypes = {
   pointWidth: PropTypes.number,
   pointWidthAccessor: PropTypes.func,
   strokeWidth: PropTypes.number,
-  isSubDomainSticky: PropTypes.bool,
-  limitSubDomain: PropTypes.func,
+  isXSubDomainSticky: PropTypes.bool,
+  limitXSubDomain: PropTypes.func,
 };
 
 DataProvider.defaultProps = {
@@ -566,6 +566,6 @@ DataProvider.defaultProps = {
   yAccessor: d => d.value,
   yAxisWidth: 50,
   ySubDomain: null,
-  isSubDomainSticky: false,
-  limitSubDomain: null,
+  isXSubDomainSticky: false,
+  limitXSubDomain: null,
 };

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -56,12 +56,12 @@ class Scaler extends Component {
 
     if (
       !isEqual(
-        prevProps.dataContext.subDomain,
-        this.props.dataContext.subDomain
+        prevProps.dataContext.xSubDomain,
+        this.props.dataContext.xSubDomain
       )
     ) {
       // eslint-disable-next-line
-      this.setState({ subDomain: this.props.dataContext.subDomain });
+      this.setState({ xSubDomain: this.props.dataContext.xSubDomain });
     }
     if (
       !isEqual(
@@ -162,9 +162,9 @@ class Scaler extends Component {
     );
     // Calculate new domain, map to timestamps (not dates)
     const newSubDomain = newScale.domain().map(Number);
-    // Update DataProvider's subDomain
-    // No need to set new subDomain state here since we
-    // listen for subDomain change in componentDidUpdate.
+    // Update DataProvider's xSubDomain
+    // No need to set new xSubDomain state here since we
+    // listen for xSubDomain change in componentDidUpdate.
     this.props.dataContext.subDomainChanged(newSubDomain);
     return newSubDomain;
   };

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -53,6 +53,16 @@ class Scaler extends Component {
         }
       }
     });
+
+    if (
+      !isEqual(
+        prevProps.dataContext.subDomain,
+        this.props.dataContext.subDomain
+      )
+    ) {
+      // eslint-disable-next-line
+      this.setState({ subDomain: this.props.dataContext.subDomain });
+    }
     if (
       !isEqual(
         prevProps.dataContext.externalSubDomain,
@@ -64,6 +74,7 @@ class Scaler extends Component {
         subDomain: this.props.dataContext.externalSubDomain,
       });
     }
+
     if (
       Object.keys(domainUpdate).length ||
       Object.keys(transformUpdate).length
@@ -97,7 +108,6 @@ class Scaler extends Component {
     if (!isEqual(prevExternalBaseDomain, nextExternalBaseDomain)) {
       // External base domain changed (props on DataProvider)
       // Reset state
-
       // eslint-disable-next-line
       this.setState({
         subDomain: nextExternalBaseDomain,
@@ -152,10 +162,9 @@ class Scaler extends Component {
     );
     // Calculate new domain, map to timestamps (not dates)
     const newSubDomain = newScale.domain().map(Number);
-    // Update dataproviders subdomains changed
-    this.setState({
-      subDomain: newSubDomain,
-    });
+    // Update DataProvider's subDomain
+    // No need to set new subDomain state here since we
+    // listen for subDomain change in componentDidUpdate.
     this.props.dataContext.subDomainChanged(newSubDomain);
     return newSubDomain;
   };


### PR DESCRIPTION
- if the prop `isXSubDomainSticky` is set to `true`, the `xSubDomain` state will be updated at every `updateInterval`, similarly to `xDomain`
- if the prop `limitXSubDomain` is provided, it allows the external application to limit the value of `xSubDomain` in  `xSubDomainChanged`, i.e. whenever the `xSubDomain` is manually changed by zoom or pan