### PR TITLE
call limitXSubDomain inside getSubDomain

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -62,7 +62,8 @@ export default class DataProvider extends Component {
   state = {
     xSubDomain: DataProvider.getXSubDomain(
       this.props.xDomain,
-      this.props.xSubDomain
+      this.props.xSubDomain,
+      this.props.limitXSubDomain
     ),
     xDomain: this.props.xDomain,
     loaderConfig: {},
@@ -165,7 +166,8 @@ export default class DataProvider extends Component {
     if (!isEqual(this.props.xDomain, prevProps.xDomain)) {
       const newXSubDomain = DataProvider.getXSubDomain(
         this.props.xDomain,
-        this.props.xSubDomain
+        this.props.xSubDomain,
+        this.props.limitXSubDomain
       );
       // eslint-disable-next-line
       this.setState(
@@ -197,22 +199,23 @@ export default class DataProvider extends Component {
     clearInterval(this.fetchInterval);
   }
 
-  static getXSubDomain = (xDomain, xSubDomain) => {
+  static getXSubDomain = (xDomain, xSubDomain, limitXSubDomain) => {
     if (!xSubDomain) {
       return xDomain;
     }
+    const newXSubDomain = limitXSubDomain(xSubDomain);
     const xDomainLength = xDomain[1] - xDomain[0];
-    const xSubDomainLength = xSubDomain[1] - xSubDomain[0];
+    const xSubDomainLength = newXSubDomain[1] - newXSubDomain[0];
     if (xDomainLength < xSubDomainLength) {
       return xDomain;
     }
-    if (xSubDomain[0] < xDomain[0]) {
+    if (newXSubDomain[0] < xDomain[0]) {
       return [xDomain[0], xDomain[0] + xSubDomainLength];
     }
-    if (xSubDomain[1] > xDomain[1]) {
+    if (newXSubDomain[1] > xDomain[1]) {
       return [xDomain[1] - xSubDomainLength, xDomain[1]];
     }
-    return xSubDomain;
+    return newXSubDomain;
   };
 
   getSeriesObjects = () => {
@@ -245,12 +248,18 @@ export default class DataProvider extends Component {
     if (updateInterval) {
       this.fetchInterval = setInterval(() => {
         const { xDomain, xSubDomain } = this.state;
+        const newXDomain = xDomain.map(d => d + updateInterval);
+        const newXSubDomain = this.props.isXSubDomainSticky
+          ? DataProvider.getXSubDomain(
+              newXDomain,
+              xSubDomain.map(d => d + updateInterval),
+              this.props.limitXSubDomain
+            )
+          : xSubDomain;
         this.setState(
           {
-            xDomain: xDomain.map(d => d + updateInterval),
-            xSubDomain: this.props.isXSubDomainSticky
-              ? xSubDomain.map(d => d + updateInterval)
-              : xSubDomain,
+            xDomain: newXDomain,
+            xSubDomain: newXSubDomain,
           },
           () => {
             Promise.map(this.props.series, s =>
@@ -417,7 +426,11 @@ export default class DataProvider extends Component {
 
   xSubDomainChanged = xSubDomain => {
     const current = this.state.xSubDomain;
-    const newXSubDomain = this.props.limitXSubDomain(xSubDomain);
+    const newXSubDomain = DataProvider.getXSubDomain(
+      this.state.xDomain,
+      xSubDomain,
+      this.props.limitXSubDomain
+    );
     if (isEqual(newXSubDomain, current)) {
       return;
     }
@@ -572,8 +585,7 @@ DataProvider.propTypes = {
   // will be increased at every interval (similarly to xDomain)
   isXSubDomainSticky: PropTypes.bool,
   // xSubDomain => newXSubDomain
-  // function to allow limitation of the value of
-  // xSubDomain on manual change (e.g. by zoom or pan)
+  // function to allow limitation of the value of xSubDomain
   limitXSubDomain: PropTypes.func,
 };
 

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -202,6 +202,7 @@ export default class DataProvider extends Component {
   static getXSubDomain = (
     xDomain,
     xSubDomain,
+    // eslint-disable-next-line no-shadow
     limitXSubDomain = xSubDomain => xSubDomain
   ) => {
     if (!xSubDomain) {

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -199,7 +199,11 @@ export default class DataProvider extends Component {
     clearInterval(this.fetchInterval);
   }
 
-  static getXSubDomain = (xDomain, xSubDomain, limitXSubDomain) => {
+  static getXSubDomain = (
+    xDomain,
+    xSubDomain,
+    limitXSubDomain = xSubDomain => xSubDomain
+  ) => {
     if (!xSubDomain) {
       return xDomain;
     }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -3,9 +3,7 @@ import { DataProvider } from 'src/';
 
 const { getXSubDomain } = DataProvider;
 
-const limitXSubDomain = xSubDomain => xSubDomain;
-
-const limitXSubDomain2 = xSubDomain => {
+const limitXSubDomain = xSubDomain => {
   const xSubDomainLength = xSubDomain[1] - xSubDomain[0];
   const xSubDomainEnd = Math.min(90, xSubDomain[1]);
   return [xSubDomainEnd - xSubDomainLength, xSubDomainEnd];
@@ -15,51 +13,37 @@ describe('getXSubDomain', () => {
   it('handles the base case', () => {
     const xDomain = [0, 100];
     const xSubDomain = [25, 75];
-    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain)).toMatch(
-      xSubDomain
-    );
+    expect(getXSubDomain(xDomain, xSubDomain)).toMatch(xSubDomain);
   });
 
   it('handles when the subdomain goes longer', () => {
     const xDomain = [50, 100];
     const xSubDomain = [95, 105];
-    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain)).toMatch([
-      90,
-      100,
-    ]);
+    expect(getXSubDomain(xDomain, xSubDomain)).toMatch([90, 100]);
   });
 
   it('handles when the subdomain goes shorter', () => {
     const xDomain = [50, 100];
     const xSubDomain = [45, 55];
-    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain)).toMatch([
-      50,
-      60,
-    ]);
+    expect(getXSubDomain(xDomain, xSubDomain)).toMatch([50, 60]);
   });
 
   it('handles when the subdomain is outside', () => {
     const xDomain = [50, 100];
     const xSubDomain = [150, 160];
-    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain)).toMatch([
-      90,
-      100,
-    ]);
+    expect(getXSubDomain(xDomain, xSubDomain)).toMatch([90, 100]);
   });
 
   it('handles when the subdomain is longer than the domain', () => {
     const xDomain = [50, 100];
     const xSubDomain = [25, 125];
-    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain)).toMatch([
-      50,
-      100,
-    ]);
+    expect(getXSubDomain(xDomain, xSubDomain)).toMatch([50, 100]);
   });
 
   it('handles limitXSubDomain', () => {
     const xDomain = [50, 100];
     const xSubDomain = [95, 105];
-    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain2)).toMatch([
+    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain)).toMatch([
       80,
       90,
     ]);

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -3,34 +3,65 @@ import { DataProvider } from 'src/';
 
 const { getXSubDomain } = DataProvider;
 
+const limitXSubDomain = xSubDomain => xSubDomain;
+
+const limitXSubDomain2 = xSubDomain => {
+  const xSubDomainLength = xSubDomain[1] - xSubDomain[0];
+  const xSubDomainEnd = Math.min(90, xSubDomain[1]);
+  return [xSubDomainEnd - xSubDomainLength, xSubDomainEnd];
+};
+
 describe('getXSubDomain', () => {
   it('handles the base case', () => {
     const xDomain = [0, 100];
     const xSubDomain = [25, 75];
-    expect(getXSubDomain(xDomain, xSubDomain)).toMatch(xSubDomain);
+    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain)).toMatch(
+      xSubDomain
+    );
   });
 
   it('handles when the subdomain goes longer', () => {
     const xDomain = [50, 100];
     const xSubDomain = [95, 105];
-    expect(getXSubDomain(xDomain, xSubDomain)).toMatch([90, 100]);
+    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain)).toMatch([
+      90,
+      100,
+    ]);
   });
 
   it('handles when the subdomain goes shorter', () => {
     const xDomain = [50, 100];
     const xSubDomain = [45, 55];
-    expect(getXSubDomain(xDomain, xSubDomain)).toMatch([50, 60]);
+    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain)).toMatch([
+      50,
+      60,
+    ]);
   });
 
   it('handles when the subdomain is outside', () => {
     const xDomain = [50, 100];
     const xSubDomain = [150, 160];
-    expect(getXSubDomain(xDomain, xSubDomain)).toMatch([90, 100]);
+    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain)).toMatch([
+      90,
+      100,
+    ]);
   });
 
   it('handles when the subdomain is longer than the domain', () => {
     const xDomain = [50, 100];
     const xSubDomain = [25, 125];
-    expect(getXSubDomain(xDomain, xSubDomain)).toMatch([50, 100]);
+    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain)).toMatch([
+      50,
+      100,
+    ]);
+  });
+
+  it('handles limitXSubDomain', () => {
+    const xDomain = [50, 100];
+    const xSubDomain = [95, 105];
+    expect(getXSubDomain(xDomain, xSubDomain, limitXSubDomain2)).toMatch([
+      80,
+      90,
+    ]);
   });
 });


### PR DESCRIPTION
this is done to ensure that `xSubDomain` is limited at all times instead of only within `onSubDomainChanged`