### PR TITLE
Bring min/max to the scatterplots

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -284,6 +284,8 @@ export default class DataProvider extends Component {
       pointWidthAccessor,
       strokeWidth,
       xAccessor,
+      x0Accessor,
+      x1Accessor,
       y0Accessor,
       y1Accessor,
       yAccessor,
@@ -305,6 +307,16 @@ export default class DataProvider extends Component {
         series.xAccessor,
         collection.xAccessor,
         xAccessor
+      ),
+      x0Accessor: firstDefined(
+        series.x0Accessor,
+        collection.x0Accessor,
+        x0Accessor
+      ),
+      x1Accessor: firstDefined(
+        series.x1Accessor,
+        collection.x1Accessor,
+        x1Accessor
       ),
       yAccessor: firstDefined(
         series.yAccessor,

--- a/src/components/Points/index.js
+++ b/src/components/Points/index.js
@@ -10,7 +10,11 @@ import { boundedSeries } from '../../utils/boundedseries';
 const propTypes = {
   data: PropTypes.arrayOf(dataPointPropType).isRequired,
   xAccessor: accessorFuncPropType.isRequired,
+  x0Accessor: accessorFuncPropType,
+  x1Accessor: accessorFuncPropType,
   yAccessor: accessorFuncPropType.isRequired,
+  y0Accessor: accessorFuncPropType,
+  y1Accessor: accessorFuncPropType,
   xScale: scaleFuncPropType.isRequired,
   yScale: scaleFuncPropType.isRequired,
   color: PropTypes.string.isRequired,
@@ -26,12 +30,20 @@ const defaultProps = {
   pointWidth: null,
   pointWidthAccessor: null,
   strokeWidth: null,
+  x0Accessor: null,
+  x1Accessor: null,
+  y0Accessor: null,
+  y1Accessor: null,
 };
 
 const Points = ({
   data,
   xAccessor,
+  x0Accessor,
+  x1Accessor,
   yAccessor,
+  y0Accessor,
+  y1Accessor,
   xScale,
   yScale,
   color,
@@ -41,6 +53,8 @@ const Points = ({
   pointWidthAccessor,
   strokeWidth,
 }) => {
+  const getX = x => boundedSeries(xScale(x));
+  const getY = y => boundedSeries(yScale(y));
   const points = data.map(d => {
     let width = 0;
     if (pointWidthAccessor) {
@@ -52,17 +66,53 @@ const Points = ({
     } else {
       width = 6;
     }
-    return (
+    const uiElements = [];
+
+    const cx = getX(xAccessor(d));
+    const cy = getY(yAccessor(d));
+
+    if (x0Accessor && x1Accessor && y0Accessor && y1Accessor) {
+      const [x0, x1, y0, y1] = [
+        x0Accessor,
+        x1Accessor,
+        y0Accessor,
+        y1Accessor,
+      ].map(f => f(d));
+      const polygon = [
+        // left
+        `${getX(x0)},${cy}`,
+        // top
+        `${cx},${getY(y1)}`,
+        // right
+        `${getX(x1)},${cy}`,
+        // bottom
+        `${cx},${getY(y0)}`,
+      ].join(' ');
+      uiElements.push(
+        <polygon
+          key={`${x0},${y0}-${x1},${y1}`}
+          className="point-area"
+          points={polygon}
+          fill={color}
+          fillOpacity={0.25}
+          stroke={color}
+          strokeWidth={1}
+        />
+      );
+    }
+
+    uiElements.push(
       <circle
         key={`${xAccessor(d)}-${yAccessor(d)}`}
         className="point"
         r={width / 2}
         opacity={opacityAccessor ? opacityAccessor(d) : opacity}
-        cx={boundedSeries(xScale(xAccessor(d)))}
-        cy={boundedSeries(yScale(yAccessor(d)))}
+        cx={cx}
+        cy={cy}
         fill={color}
       />
     );
+    return uiElements;
   });
   return <g>{points}</g>;
 };

--- a/src/components/Points/index.js
+++ b/src/components/Points/index.js
@@ -71,30 +71,30 @@ const Points = ({
     const cx = getX(xAccessor(d));
     const cy = getY(yAccessor(d));
 
-    if (x0Accessor && x1Accessor && y0Accessor && y1Accessor) {
-      const [x0, x1, y0, y1] = [
-        x0Accessor,
-        x1Accessor,
-        y0Accessor,
-        y1Accessor,
-      ].map(f => f(d));
-      const polygon = [
-        // left
-        `${getX(x0)},${cy}`,
-        // top
-        `${cx},${getY(y1)}`,
-        // right
-        `${getX(x1)},${cy}`,
-        // bottom
-        `${cx},${getY(y0)}`,
-      ].join(' ');
+    if (x0Accessor && x1Accessor) {
+      const [x0, x1] = [x0Accessor, x1Accessor].map(f => f(d));
       uiElements.push(
-        <polygon
-          key={`${x0},${y0}-${x1},${y1}`}
-          className="point-area"
-          points={polygon}
-          fill={color}
-          fillOpacity={0.25}
+        <line
+          key={`${x0},${cy}-${x1},${cy}`}
+          x1={getX(x0)}
+          y1={cy}
+          x2={getX(x1)}
+          y2={cy}
+          stroke={color}
+          strokeWidth={1}
+        />
+      );
+    }
+
+    if (y0Accessor && y1Accessor) {
+      const [y0, y1] = [y0Accessor, y1Accessor].map(f => f(d));
+      uiElements.push(
+        <line
+          key={`${cx},${y0}-${cx},${y1}`}
+          x1={cx}
+          y1={getY(y0)}
+          x2={cx}
+          y2={getY(y1)}
           stroke={color}
           strokeWidth={1}
         />

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -14,6 +14,8 @@ export const singleSeriePropType = PropTypes.shape({
   loader: PropTypes.func,
   step: PropTypes.bool,
   xAccessor: PropTypes.func,
+  x0Accessor: PropTypes.func,
+  x1Accessor: PropTypes.func,
   yAccessor: PropTypes.func,
   y0Accessor: PropTypes.func,
   y1Accessor: PropTypes.func,

--- a/stories/Scatterplot.stories.js
+++ b/stories/Scatterplot.stories.js
@@ -466,4 +466,26 @@ storiesOf('Scatterplot', module)
         </DataProvider>
       </div>
     </React.Fragment>
+  ))
+  .add('Min/Max', () => (
+    <React.Fragment>
+      <div style={{ height: '500px', width: '500px' }}>
+        <DataProvider
+          defaultLoader={scatterplotloader}
+          xDomain={[0, 1]}
+          series={[
+            { id: '1 2', color: 'steelblue' },
+            { id: '3 4', color: 'maroon' },
+          ]}
+          xAccessor={d => +d.x}
+          x0Accessor={d => +d.x * 0.9}
+          x1Accessor={d => +d.x * 1.1}
+          yAccessor={d => +d.y}
+          y0Accessor={d => +d.y * 0.9}
+          y1Accessor={d => +d.y * 1.1}
+        >
+          <Scatterplot zoomable />
+        </DataProvider>
+      </div>
+    </React.Fragment>
   ));


### PR DESCRIPTION
Introduce uncertainty to the scatterplots by using the same min/max
shaded area. The resulting polygon is defined by the uncertainty
accessors: x0Accessor, x1Accessor, y0Accessor, y1Accessor.