### PR TITLE
Clear intervals before setting new ones

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -251,6 +251,7 @@ export default class DataProvider extends Component {
   startUpdateInterval = () => {
     const { updateInterval } = this.props;
     if (updateInterval) {
+      clearInterval(this.fetchInterval);
       this.fetchInterval = setInterval(() => {
         const { xDomain, xSubDomain } = this.state;
         const newXDomain = xDomain.map(d => d + updateInterval);

--- a/stories/InteractionLayer.stories.js
+++ b/stories/InteractionLayer.stories.js
@@ -379,7 +379,11 @@ storiesOf('InteractionLayer', module)
       state = { onAreaDefined: null };
 
       componentDidMount() {
-        window.setInterval(this.toggleOnAreaDefined, 1000);
+        this.interval = setInterval(this.toggleOnAreaDefined, 1000);
+      }
+
+      componentWillUnmount() {
+        clearInterval(this.interval);
       }
 
       toggleOnAreaDefined = () => {
@@ -402,7 +406,8 @@ storiesOf('InteractionLayer', module)
             >
               <LineChart height={CHART_HEIGHT} onAreaDefined={onAreaDefined} />
             </DataProvider>
-            onAreaDefined={onAreaDefined ? 'function' : 'null'}
+            onAreaDefined:
+            {onAreaDefined ? 'function' : 'null'}
             <h2>Test</h2>
             <ol>
               <li>


### PR DESCRIPTION
When an interval is set, the old one (if there is one) should be cleared
first. This won't fix all cases of updating while the component isn't
mounted, but if the variable is overwritten, then there's no way to kill
the zombie.