### PR TITLE
Use filter instead of reduce

### DIFF
--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -198,24 +198,14 @@ class LineChartComponent extends Component {
     const filteredItems = []
       .concat(series)
       .concat(collections)
-      .reduce((items, item) => {
-        if (item.hidden) {
-          return items;
-        }
-        if (item.collectionId === undefined) {
-          return items;
-        }
-        if (
-          !(
-            (item.yAxisPlacement || yAxisPlacement) &&
+      .filter(
+        item =>
+          !item.hidden &&
+          item.collectionId === undefined &&
+          ((item.yAxisPlacement || yAxisPlacement) &&
             ((item.yAxisPlacement || yAxisPlacement) === AxisPlacement.BOTH ||
-              (item.yAxisPlacement || yAxisPlacement) === placement)
-          )
-        ) {
-          return items;
-        }
-        return [...items, item];
-      }, []);
+              (item.yAxisPlacement || yAxisPlacement) === placement))
+      );
 
     const hasCollapsed =
       filteredItems.filter(displayModeFilter(AxisDisplayMode.COLLAPSED))


### PR DESCRIPTION
Instead of using a complicated reduce function (introduced in
1f6f672c128), do it with a single filter call. This also fixes a bug
that was introduced with that change where the logic was inverted.