### PR TITLE
Correct the a logical grouping typo

### DIFF
--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -124,8 +124,8 @@ class Scaler extends Component {
       // Keep existing subdomain
       const { xSubDomain } = prevState;
       if (
-        (xSubDomain && xSubDomain[1] === prevXDomain[1]) ||
-        xSubDomain[1] >= prevXDomain[1]
+        xSubDomain &&
+        (xSubDomain[1] === prevXDomain[1] || xSubDomain[1] >= prevXDomain[1])
       ) {
         // You are looking at the end of the window
         // and the xDomain is updated


### PR DESCRIPTION
This conditional should be false if xSubDomain is not truthy, instead of
incorrectly grouping the truthiness check with the first component of
the conditional test.