### PR TITLE
Correctly handle the update events for non-touchmove

### DIFF
--- a/src/components/InteractionLayer/index.js
+++ b/src/components/InteractionLayer/index.js
@@ -119,6 +119,8 @@ class InteractionLayer extends React.Component {
       const curXScale = xScalerFactory(nextTimeSubDomain, width);
       const ts = prevXScale.invert(touchX).getTime();
       const newXPos = curXScale(ts);
+
+      const { type: d3Type } = ((d3 || {}).event || {}).sourceEvent || {};
       // hide ruler if point went out to the left of subdomain
       if (newXPos < 0) {
         this.setState({
@@ -129,7 +131,8 @@ class InteractionLayer extends React.Component {
       } else if (
         // ruler should follow points during live loading
         // except when the chart is dragging firing touchmove event
-        (((d3 || {}).event || {}).sourceEvent || {}).type === 'mousemove'
+        d3Type === 'mousemove' ||
+        d3Type === undefined
       ) {
         this.setState({ touchX: newXPos }, () =>
           this.processMouseMove(newXPos, touchY)


### PR DESCRIPTION
When there are new props for InteractionLayer, we need to update when:

  1. The mouse moves (`mousemove` event)
  2. There was no d3 event (live-loading)

All other reasons need to be ignored (eg, `touchmove` events)