### PR TITLE
Handle missing series in the subdomains

### DIFF
--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -11,6 +11,16 @@ import Axes from '../../utils/Axes';
 // the leading edge of the timeDomain.
 const FRONT_OF_WINDOW_THRESHOLD = 0.05;
 
+const containsSameItems = (a, b) => {
+  const reducer = (acc, item) => {
+    if (item.hidden) {
+      return acc;
+    }
+    return { ...acc, [item.id]: item.yDomain };
+  };
+  return isEqual(a.reduce(reducer, {}), b.reduce(reducer, {}));
+};
+
 /**
  * The scaler is the source of truth for all things related to the domains and
  * subdomains for all of the items within Griff. Note that an item can be either
@@ -59,7 +69,12 @@ class Scaler extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (!isEqual(prevProps.dataContext.series, this.props.dataContext.series)) {
+    if (
+      !containsSameItems(
+        prevProps.dataContext.series,
+        this.props.dataContext.series
+      )
+    ) {
       const domainsByItemId = {};
       const subDomainsByItemId = {};
 

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -71,10 +71,10 @@ class Scaler extends Component {
             ),
           ],
           [Axes.x]: [
-            ...(item.xDomain || Axes.x(this.state.domainsByItemId[item.id])),
+            ...Axes.x(this.state.domainsByItemId[item.id] || item.xDomain),
           ],
           [Axes.y]: [
-            ...(item.yDomain || Axes.y(this.state.domainsByItemId[item.id])),
+            ...Axes.y(this.state.domainsByItemId[item.id] || item.yDomain),
           ],
         };
         subDomainsByItemId[item.id] = {

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -59,6 +59,39 @@ class Scaler extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    if (!isEqual(prevProps.dataContext.series, this.props.dataContext.series)) {
+      const domainsByItemId = {};
+      const subDomainsByItemId = {};
+
+      const updateDomainsForItem = item => {
+        domainsByItemId[item.id] = {
+          [Axes.time]: this.props.dataContext.timeDomain,
+          [Axes.x]: [
+            ...(item.xDomain || Axes.x(this.state.domainsByItemId[item.id])),
+          ],
+          [Axes.y]: [
+            ...(item.yDomain || Axes.y(this.state.domainsByItemId[item.id])),
+          ],
+        };
+        subDomainsByItemId[item.id] = {
+          [Axes.time]: this.props.dataContext.timeSubDomain,
+          [Axes.x]: [
+            ...(item.xSubDomain ||
+              Axes.x(this.state.subDomainsByItemId[item.id])),
+          ],
+          [Axes.y]: [
+            ...(item.ySubDomain ||
+              Axes.y(this.state.subDomainsByItemId[item.id])),
+          ],
+        };
+      };
+      (this.props.dataContext.series || []).forEach(updateDomainsForItem);
+      (this.props.dataContext.collections || []).forEach(updateDomainsForItem);
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ subDomainsByItemId, domainsByItemId });
+      return;
+    }
+
     if (
       !isEqual(
         prevProps.dataContext.timeSubDomain,
@@ -120,38 +153,6 @@ class Scaler extends Component {
 
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ domainsByItemId, subDomainsByItemId });
-    }
-
-    if (!isEqual(prevProps.dataContext.series, this.props.dataContext.series)) {
-      const domainsByItemId = {};
-      const subDomainsByItemId = {};
-      []
-        .concat(this.props.dataContext.series)
-        .concat(this.props.dataContext.collections)
-        .forEach(item => {
-          domainsByItemId[item.id] = {
-            ...this.state.domainsByItemId[item.id],
-            [Axes.x]: [
-              ...(item.xDomain || Axes.x(this.state.domainsByItemId[item.id])),
-            ],
-            [Axes.y]: [
-              ...(item.yDomain || Axes.y(this.state.domainsByItemId[item.id])),
-            ],
-          };
-          subDomainsByItemId[item.id] = {
-            ...this.state.subDomainsByItemId[item.id],
-            [Axes.x]: [
-              ...(item.xSubDomain ||
-                Axes.x(this.state.subDomainsByItemId[item.id])),
-            ],
-            [Axes.y]: [
-              ...(item.ySubDomain ||
-                Axes.y(this.state.subDomainsByItemId[item.id])),
-            ],
-          };
-        });
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ subDomainsByItemId, domainsByItemId });
     }
   }
 

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -65,7 +65,11 @@ class Scaler extends Component {
 
       const updateDomainsForItem = item => {
         domainsByItemId[item.id] = {
-          [Axes.time]: this.props.dataContext.timeDomain,
+          [Axes.time]: this.props.dataContext.timeDomain || [
+            ...Axes.time(
+              this.state.domainsByItemId[item.id] || item.timeDomain
+            ),
+          ],
           [Axes.x]: [
             ...(item.xDomain || Axes.x(this.state.domainsByItemId[item.id])),
           ],

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -93,14 +93,18 @@ class Scaler extends Component {
           ],
         };
         subDomainsByItemId[item.id] = {
-          [Axes.time]: this.props.dataContext.timeSubDomain,
+          [Axes.time]: this.props.dataContext.timeSubDomain || [
+            ...Axes.time(
+              this.state.subDomainsByItemId[item.id] || item.timeSubDomain
+            ),
+          ],
           [Axes.x]: [
-            ...(item.xSubDomain ||
-              Axes.x(this.state.subDomainsByItemId[item.id])),
+            ...(Axes.x(this.state.subDomainsByItemId[item.id]) ||
+              item.xSubDomain),
           ],
           [Axes.y]: [
-            ...(item.ySubDomain ||
-              Axes.y(this.state.subDomainsByItemId[item.id])),
+            ...(Axes.y(this.state.subDomainsByItemId[item.id]) ||
+              item.ySubDomain),
           ],
         };
       };

--- a/src/utils/Axes.js
+++ b/src/utils/Axes.js
@@ -1,5 +1,10 @@
 const dimension = key => {
-  const functor = input => input[key];
+  const functor = input => {
+    if (!input) {
+      return [0, 0];
+    }
+    return input[key];
+  };
   functor.toString = () => key;
   return functor;
 };


### PR DESCRIPTION
If the series are updated, it's possible to crash because the subdomain
and domain maps in Scaler have not yet been updated. Example logical
flow:

  1. Scaler initialized with series 1.
  2. Scaler's state updated with:
     domainsByItemId: { [1]: { .. } },
     subDomainsByItemId: { [1]: { .. } },
  3. Series 2 added to DataProvider
  4. Scaler notices the new series and updates the state:
     domainsByItemId: { [1]: { .. }, [2]: { .. } },
     subDomainsByItemId: { [1]: { .. }, [2]: { .. } },

When this happens, no other scaling happens in componentDidUpdate
because everthing was reinitialized when there are new series added.

As an additional safety measure, Axes will not crash if an invalid
series is given. Instead, a domain (or subdomain) of `[0, 0]` will be
returned.