### PR TITLE
Formalize the notion of a placeholder domain

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -69,6 +69,8 @@ export default class DataProvider extends Component {
     timeDomain: this.props.timeDomain,
     loaderConfig: {},
     contextSeries: {},
+    timeDomains: {},
+    timeSubDomains: {},
     xDomains: {},
     xSubDomains: {},
     yDomains: {},
@@ -279,6 +281,8 @@ export default class DataProvider extends Component {
       pointWidthAccessor,
       strokeWidth,
       timeAccessor,
+      timeDomain: propTimeDomain,
+      timeSubDomain,
       xAccessor,
       x0Accessor,
       x1Accessor,
@@ -292,6 +296,8 @@ export default class DataProvider extends Component {
     } = this.props;
     const {
       loaderConfig,
+      timeDomains,
+      timeSubDomains,
       xDomains,
       xSubDomains,
       yDomains,
@@ -308,6 +314,12 @@ export default class DataProvider extends Component {
       series.xDomain ||
       propXDomain ||
       xDomains[series.id] ||
+      PLACEHOLDER_DOMAIN;
+    const timeDomain =
+      collection.timeDomain ||
+      series.timeDomain ||
+      timeDomains[series.id] ||
+      propTimeDomain ||
       PLACEHOLDER_DOMAIN;
     return {
       drawPoints: collection.drawPoints,
@@ -375,6 +387,13 @@ export default class DataProvider extends Component {
         (series.collectionId
           ? collection.yAxisDisplayMode
           : series.yAxisDisplayMode) || collection.yAxisDisplayMode,
+      timeDomain,
+      timeSubDomain:
+        collection.timeSubDomain ||
+        series.timeSubDomain ||
+        timeSubDomains[series.id] ||
+        timeSubDomain ||
+        timeDomain,
       xDomain,
       xSubDomain:
         collection.xSubDomain ||
@@ -419,6 +438,20 @@ export default class DataProvider extends Component {
     };
     const stateUpdates = {};
     if (reason === 'MOUNTED') {
+      const calculatedTimeDomain = calculateDomainFromData(
+        loaderConfig.data,
+        loaderConfig.timeAccessor || this.props.timeAccessor
+      );
+      const calculatedTimeSubDomain = calculatedTimeDomain;
+      stateUpdates.timeDomains = {
+        ...this.state.timeDomains,
+        [id]: calculatedTimeDomain,
+      };
+      stateUpdates.timeSubDomains = {
+        ...this.state.timeSubDomains,
+        [id]: calculatedTimeSubDomain,
+      };
+
       // We were not given an xDomain, so we need to calculate one based on
       // the loaded data.
       const xDomain = calculateDomainFromData(

--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -5,7 +5,7 @@ import * as d3 from 'd3';
 import isEqual from 'lodash.isequal';
 import DataContext from '../../context/Data';
 import GriffPropTypes, { seriesPropType } from '../../utils/proptypes';
-import Scaler from '../Scaler';
+import Scaler, { PLACEHOLDER_DOMAIN } from '../Scaler';
 
 const calculateDomainFromData = (
   data,
@@ -297,14 +297,18 @@ export default class DataProvider extends Component {
       yDomains,
       ySubDomains,
     } = this.state;
-    const yDomain = collection.yDomain ||
+    const yDomain =
+      collection.yDomain ||
       series.yDomain ||
       propYDomain ||
-      yDomains[series.id] || [0, 1];
-    const xDomain = collection.xDomain ||
+      yDomains[series.id] ||
+      PLACEHOLDER_DOMAIN;
+    const xDomain =
+      collection.xDomain ||
       series.xDomain ||
       propXDomain ||
-      xDomains[series.id] || [0, 1];
+      xDomains[series.id] ||
+      PLACEHOLDER_DOMAIN;
     return {
       drawPoints: collection.drawPoints,
       hidden: collection.hidden,

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -11,6 +11,12 @@ import Axes from '../../utils/Axes';
 // the leading edge of the timeDomain.
 const FRONT_OF_WINDOW_THRESHOLD = 0.05;
 
+/**
+ * Provide a placeholder domain so that we can test for validity later, but
+ * it can be safely operated on like a real domain.
+ */
+export const PLACEHOLDER_DOMAIN = [0, 0];
+
 const containsSameItems = (a, b) => {
   const reducer = (acc, item) => {
     if (item.hidden) {
@@ -19,6 +25,13 @@ const containsSameItems = (a, b) => {
     return { ...acc, [item.id]: item.yDomain };
   };
   return isEqual(a.reduce(reducer, {}), b.reduce(reducer, {}));
+};
+
+const stripPlaceholderDomain = domain => {
+  if (isEqual(PLACEHOLDER_DOMAIN, domain)) {
+    return undefined;
+  }
+  return domain;
 };
 
 /**
@@ -81,30 +94,36 @@ class Scaler extends Component {
       const updateDomainsForItem = item => {
         domainsByItemId[item.id] = {
           [Axes.time]: this.props.dataContext.timeDomain || [
-            ...Axes.time(
-              this.state.domainsByItemId[item.id] || item.timeDomain
-            ),
+            ...(stripPlaceholderDomain(
+              Axes.time(this.state.domainsByItemId[item.id])
+            ) || item.timeDomain),
           ],
           [Axes.x]: [
-            ...Axes.x(this.state.domainsByItemId[item.id] || item.xDomain),
+            ...(stripPlaceholderDomain(
+              Axes.x(this.state.domainsByItemId[item.id])
+            ) || item.xDomain),
           ],
           [Axes.y]: [
-            ...Axes.y(this.state.domainsByItemId[item.id] || item.yDomain),
+            ...(stripPlaceholderDomain(
+              Axes.y(this.state.domainsByItemId[item.id])
+            ) || item.yDomain),
           ],
         };
         subDomainsByItemId[item.id] = {
           [Axes.time]: this.props.dataContext.timeSubDomain || [
-            ...Axes.time(
-              this.state.subDomainsByItemId[item.id] || item.timeSubDomain
-            ),
+            ...(stripPlaceholderDomain(
+              Axes.time(this.state.subDomainsByItemId[item.id])
+            ) || item.timeSubDomain),
           ],
           [Axes.x]: [
-            ...(Axes.x(this.state.subDomainsByItemId[item.id]) ||
-              item.xSubDomain),
+            ...(stripPlaceholderDomain(
+              Axes.x(this.state.subDomainsByItemId[item.id])
+            ) || item.xSubDomain),
           ],
           [Axes.y]: [
-            ...(Axes.y(this.state.subDomainsByItemId[item.id]) ||
-              item.ySubDomain),
+            ...(stripPlaceholderDomain(
+              Axes.y(this.state.subDomainsByItemId[item.id])
+            ) || item.ySubDomain),
           ],
         };
       };


### PR DESCRIPTION
Introduce a placeholder domain (owned by Scaler) which will allow for
children to assume a domain exists and is valid, but the Scaler can know
whether or not there is a valid domain or not.

This allows Scaler to use the computed domains and subdomains when
necessary, and use the specified ones when not.