### PR TITLE
Removed the check to see if a ruler exists

### DIFF
--- a/src/components/InteractionLayer/index.js
+++ b/src/components/InteractionLayer/index.js
@@ -451,10 +451,6 @@ class InteractionLayer extends React.Component {
   };
 
   setRulerPoints = xpos => {
-    const { ruler } = this.props;
-    if (!ruler || !ruler.visible) {
-      return [];
-    }
     const rulerPoints = this.getRulerPoints(xpos);
     this.setState({ points: rulerPoints });
 


### PR DESCRIPTION
This check prevents the `onMouseMove` api from providing data if the ruler is hidden/doesn't exist - breaking opints cursor overview.

Not sure if this code was added to solve some kind of other bug though