### PR TITLE
limit timeSubDomain in Scaler

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -617,6 +617,7 @@ export default class DataProvider extends Component {
       externalTimeSubDomain,
       yAxisWidth,
       timeSubDomainChanged: this.timeSubDomainChanged,
+      limitTimeSubDomain: this.props.limitTimeSubDomain,
       contextSeries: seriesObjects.map(s => ({
         ...contextSeries[s.id],
         ...s,

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -57,6 +57,7 @@ class Scaler extends Component {
       timeDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
       timeSubDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
       timeSubDomainChanged: PropTypes.func.isRequired,
+      limitTimeSubDomain: PropTypes.func,
       externalXSubDomain: PropTypes.arrayOf(PropTypes.number),
       series: seriesPropType.isRequired,
       collections: GriffPropTypes.collections.isRequired,
@@ -258,6 +259,12 @@ class Scaler extends Component {
       newSubDomains[itemId] = { ...(subDomainsByItemId[itemId] || {}) };
       Object.keys(changedDomainsById[itemId]).forEach(axis => {
         let newSubDomain = changedDomainsById[itemId][axis];
+        if (axis === String(Axes.time)) {
+          newSubDomain = this.props.dataContext.limitTimeSubDomain(
+            newSubDomain
+          );
+        }
+
         const newSpan = newSubDomain[1] - newSubDomain[0];
 
         const existingSubDomain =


### PR DESCRIPTION
`Scaler` was setting its `timeSubDomain` state before it being limited in `DataProvider`, causing the `timeSubDomain` to jump around (and hence the ruler to jump around) when attempting to pan the chart passed the limit imposed within `limitTimeSubDomain`