### PR TITLE
Add lines on scatterplots

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -275,6 +275,7 @@ export default class DataProvider extends Component {
 
   enrichSeries = (series, collection = {}) => {
     const {
+      drawLines,
       opacity,
       opacityAccessor,
       pointWidth,
@@ -327,6 +328,11 @@ export default class DataProvider extends Component {
       data: [],
       ...deleteUndefinedFromObject(loaderConfig[series.id]),
       ...deleteUndefinedFromObject(series),
+      drawLines: firstDefined(
+        series.drawLines,
+        collection.drawLines,
+        drawLines
+      ),
       timeAccessor: firstDefined(
         series.timeAccessor,
         collection.timeAccessor,
@@ -633,6 +639,7 @@ export default class DataProvider extends Component {
 }
 
 DataProvider.propTypes = {
+  drawLines: PropTypes.bool,
   timeDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
   timeSubDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
   xDomain: PropTypes.arrayOf(PropTypes.number.isRequired),
@@ -674,6 +681,7 @@ DataProvider.propTypes = {
 DataProvider.defaultProps = {
   collections: [],
   defaultLoader: null,
+  drawLines: undefined,
   onTimeSubDomainChanged: null,
   opacity: 1.0,
   opacityAccessor: null,

--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -6,17 +6,18 @@ import { boundedSeries } from '../../utils/boundedseries';
 
 const Line = ({
   data,
-  timeAccessor,
+  xAxisAccessor,
+  xScale,
   yAccessor,
   y0Accessor,
   y1Accessor,
-  xScale,
   yScale,
   color,
   step,
   hidden,
   drawPoints,
   strokeWidth,
+  opacity,
   pointWidth,
   pointWidthAccessor,
   clipPath,
@@ -27,25 +28,25 @@ const Line = ({
     line = d3
       .line()
       .curve(d3.curveStepAfter)
-      .x(d => boundedSeries(xScale(timeAccessor(d))))
+      .x(d => boundedSeries(xScale(xAxisAccessor(d))))
       .y(d => boundedSeries(yScale(yAccessor(d))));
     if (!drawPoints && y0Accessor && y1Accessor) {
       area = d3
         .area()
         .curve(d3.curveStepAfter)
-        .x(d => boundedSeries(xScale(timeAccessor(d))))
+        .x(d => boundedSeries(xScale(xAxisAccessor(d))))
         .y0(d => boundedSeries(yScale(y0Accessor(d))))
         .y1(d => boundedSeries(yScale(y1Accessor(d))));
     }
   } else {
     line = d3
       .line()
-      .x(d => boundedSeries(xScale(timeAccessor(d))))
+      .x(d => boundedSeries(xScale(xAxisAccessor(d))))
       .y(d => boundedSeries(yScale(yAccessor(d))));
     if (!drawPoints && y0Accessor && y1Accessor) {
       area = d3
         .area()
-        .x(d => boundedSeries(xScale(timeAccessor(d))))
+        .x(d => boundedSeries(xScale(xAxisAccessor(d))))
         .y0(d => boundedSeries(yScale(y0Accessor(d))))
         .y1(d => boundedSeries(yScale(y1Accessor(d))));
     }
@@ -56,10 +57,10 @@ const Line = ({
     circles = (
       <Points
         data={data.filter(d => {
-          const x = timeAccessor(d);
+          const x = xAxisAccessor(d);
           return x >= xSubDomain[0] && x <= xSubDomain[1];
         })}
-        xAccessor={timeAccessor}
+        xAccessor={xAxisAccessor}
         yAccessor={yAccessor}
         xScale={xScale}
         yScale={yScale}
@@ -92,6 +93,7 @@ const Line = ({
         style={{
           stroke: color,
           strokeWidth: `${strokeWidth}px`,
+          strokeOpacity: opacity,
           fill: 'none',
           display: hidden ? 'none' : 'inherit',
         }}
@@ -106,8 +108,8 @@ Line.propTypes = {
   yScale: PropTypes.func.isRequired,
   // eslint-disable-next-line
   data: PropTypes.array.isRequired,
-  // Data can take any form as long as the timeAccessor and yAccessors are set.
-  timeAccessor: PropTypes.func.isRequired,
+  // Data can take any form as long as the xAxisAccessor and yAccessors are set.
+  xAxisAccessor: PropTypes.func.isRequired,
   yAccessor: PropTypes.func.isRequired,
   y0Accessor: PropTypes.func,
   y1Accessor: PropTypes.func,
@@ -115,6 +117,7 @@ Line.propTypes = {
   step: PropTypes.bool,
   hidden: PropTypes.bool,
   drawPoints: PropTypes.bool,
+  opacity: PropTypes.number,
   pointWidth: PropTypes.number,
   pointWidthAccessor: PropTypes.func,
   strokeWidth: PropTypes.number,
@@ -125,6 +128,7 @@ Line.defaultProps = {
   step: false,
   hidden: false,
   drawPoints: false,
+  opacity: 1,
   pointWidth: 6,
   pointWidthAccessor: null,
   strokeWidth: 1,

--- a/src/components/LineCollection/index.js
+++ b/src/components/LineCollection/index.js
@@ -17,6 +17,7 @@ const LineCollection = props => {
     series,
     width,
     height,
+    xAxis,
     xScalerFactory,
     pointWidth,
     scaleX,
@@ -40,9 +41,7 @@ const LineCollection = props => {
     }
     const { id } = s;
     const xScale = xScalerFactory(
-      scaleX
-        ? Axes.time(subDomainsByItemId[id])
-        : Axes.time(domainsByItemId[id]),
+      scaleX ? xAxis(subDomainsByItemId[id]) : xAxis(domainsByItemId[id]),
       width
     );
     const yScale = createYScale(
@@ -54,6 +53,7 @@ const LineCollection = props => {
       <Line
         key={s.id}
         {...s}
+        xAxisAccessor={xAxis === Axes.time ? s.timeAccessor : s.xAccessor}
         xScale={xScale}
         yScale={yScale}
         clipPath={clipPath}
@@ -74,6 +74,7 @@ const LineCollection = props => {
 LineCollection.propTypes = {
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
+  xAxis: PropTypes.oneOf(Axes.HORIZONTAL),
   series: seriesPropType,
   pointWidth: PropTypes.number,
   scaleX: PropTypes.bool,
@@ -92,6 +93,7 @@ LineCollection.defaultProps = {
   pointWidth: 6,
   scaleX: true,
   scaleY: true,
+  xAxis: Axes.time,
 };
 
 export default props => (

--- a/src/components/PointCollection/index.js
+++ b/src/components/PointCollection/index.js
@@ -23,18 +23,20 @@ const PointCollection = ({
   subDomainsByItemId,
   xScalerFactory,
 }) => {
-  const points = series.filter(s => !s.hidden).map(s => {
-    // TODO: We can't use [s.collectionId || s.id] on the x axis. I'm not
-    // entirely sure why; I think it's because the collection's x domain is not
-    // correctly calculated to the data's extent. I have not looked into it
-    // because it doesn't really matter yet, but it will at some point.
-    const xScale = xScalerFactory(Axes.x(subDomainsByItemId[s.id]), width);
-    const yScale = createYScale(
-      Axes.y(subDomainsByItemId[s.collectionId || s.id]),
-      height
-    );
-    return <Points key={s.id} {...s} xScale={xScale} yScale={yScale} />;
-  });
+  const points = series
+    .filter(s => !s.hidden && s.drawPoints !== false)
+    .map(s => {
+      // TODO: We can't use [s.collectionId || s.id] on the x axis. I'm not
+      // entirely sure why; I think it's because the collection's x domain is not
+      // correctly calculated to the data's extent. I have not looked into it
+      // because it doesn't really matter yet, but it will at some point.
+      const xScale = xScalerFactory(Axes.x(subDomainsByItemId[s.id]), width);
+      const yScale = createYScale(
+        Axes.y(subDomainsByItemId[s.collectionId || s.id]),
+        height
+      );
+      return <Points key={s.id} {...s} xScale={xScale} yScale={yScale} />;
+    });
 
   return (
     <g width={width} height={height}>

--- a/src/components/Scatterplot/index.js
+++ b/src/components/Scatterplot/index.js
@@ -16,6 +16,7 @@ import AxisPlacement from '../AxisPlacement';
 import GridLines from '../GridLines';
 import Axes from '../../utils/Axes';
 import AxisCollection from '../AxisCollection';
+import LineCollection from '../LineCollection';
 
 const propTypes = {
   grid: GriffPropTypes.grid,
@@ -54,6 +55,7 @@ const X_AXIS_HEIGHT = 50;
 
 const ScatterplotComponent = ({
   grid,
+  series,
   size: { width, height },
   zoomable,
   onClick,
@@ -94,6 +96,11 @@ const ScatterplotComponent = ({
         <svg style={{ width: '100%', height: '100%' }}>
           <GridLines grid={grid} {...chartSize} />
           <PointCollection {...chartSize} />
+          <LineCollection
+            {...chartSize}
+            series={series.filter(s => !!s.drawLines)}
+            xAxis={Axes.x}
+          />
           <InteractionLayer
             {...chartSize}
             onClick={onClick}

--- a/src/utils/Axes.js
+++ b/src/utils/Axes.js
@@ -9,6 +9,10 @@ const dimension = key => {
   return functor;
 };
 
+const time = dimension('time');
+const x = dimension('x');
+const y = dimension('y');
+
 export default {
   /**
    * {@code time} is a reference to the time dimension of the plotted data.
@@ -16,7 +20,7 @@ export default {
    * example: scatterplots might not have one) but it's required for series
    * which need it, such as a line charts.
    */
-  time: dimension('time'),
+  time,
 
   /**
    * {@code x} is the x-dimension of a plotted point. For time series charts,
@@ -24,7 +28,7 @@ export default {
    * {@code time = x}. However, for a scatterplot, this is used to determine
    * where the data point will lie along the x axis.
    */
-  x: dimension('x'),
+  x,
 
   /**
    * {@code y} is the y-dimension of a plotted point. For time series charts,
@@ -32,9 +36,9 @@ export default {
    * use this to place the point along the y axis (for example, by using the
    * value from another coupled time series).
    */
-  y: dimension('y'),
+  y,
 
-  HORIZONTAL: ['x', 'time'],
+  HORIZONTAL: [x, time],
 
   VERTICAL: ['y'],
 

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -10,7 +10,14 @@ export const singleSeriePropType = PropTypes.shape({
   collectionId: idPropType,
   color: PropTypes.string,
   hidden: PropTypes.bool,
+  opacity: PropTypes.number,
   strokeWidth: PropTypes.number,
+  /**
+   * If unset, this defaults to {@code true} for line charts and {@code false}
+   * for scatterplots.
+   * This will likely be consolidated into a standardized default in the future.
+   */
+  drawLines: PropTypes.bool,
   drawPoints: PropTypes.bool,
   loader: PropTypes.func,
   step: PropTypes.bool,
@@ -104,8 +111,15 @@ const collection = PropTypes.shape({
   id: idPropType.isRequired,
   // This the color used when referencing the collection (eg, the common axis)
   color: PropTypes.string,
+  /**
+   * If unset, this defaults to {@code true} for line charts and {@code false}
+   * for scatterplots.
+   * This will likely be consolidated into a standardized default in the future.
+   */
+  drawLines: PropTypes.bool,
   drawPoints: PropTypes.bool,
   hidden: PropTypes.bool,
+  opacity: PropTypes.number,
   strokeWidth: PropTypes.number,
   xAccessor: PropTypes.func,
   yAxisDisplayMode: PropTypes.instanceOf(AxisDisplayMode),

--- a/stories/Scatterplot.stories.js
+++ b/stories/Scatterplot.stories.js
@@ -621,4 +621,79 @@ storiesOf('Scatterplot', module)
         </DataProvider>
       </div>
     </React.Fragment>
+  ))
+  .add('Draw lines', () => (
+    <React.Fragment>
+      <div>
+        <h3>Set on DataProvider</h3>
+        <div style={{ height: '500px', width: '100%' }}>
+          <DataProvider
+            defaultLoader={scatterplotloader}
+            timeDomain={[0, 1]}
+            series={[
+              { id: 'sincos', color: '#ACF39D' },
+              { id: 'sintan', color: '#E85F5C' },
+              { id: 'pow', color: '#9CFFFA' },
+            ]}
+            xAccessor={d => +d.x}
+            yAccessor={d => +d.y}
+            drawLines
+          >
+            <Scatterplot zoomable />
+          </DataProvider>
+        </div>
+      </div>
+      <div>
+        <h3>Set on the series</h3>
+        <div style={{ height: '500px', width: '100%' }}>
+          <DataProvider
+            defaultLoader={scatterplotloader}
+            timeDomain={[0, 1]}
+            series={[
+              { id: 'sincos', color: '#ACF39D', drawLines: true },
+              {
+                id: 'sintan',
+                color: '#E85F5C',
+                drawLines: true,
+                drawPoints: false,
+                strokeWidth: 20,
+                opacity: 0.2,
+              },
+              { id: 'pow', color: '#9CFFFA' },
+            ]}
+            xAccessor={d => +d.x}
+            yAccessor={d => +d.y}
+          >
+            <Scatterplot zoomable />
+          </DataProvider>
+        </div>
+      </div>
+      <div>
+        <h3>Set on the collection</h3>
+        <div style={{ height: '500px', width: '100%' }}>
+          <DataProvider
+            defaultLoader={scatterplotloader}
+            timeDomain={[0, 1]}
+            series={[
+              { id: 'sincos', color: '#ACF39D', collectionId: 'scatter' },
+              { id: 'sintan', color: '#E85F5C', collectionId: 'scatter' },
+              { id: 'pow', color: '#9CFFFA' },
+            ]}
+            collections={[
+              {
+                id: 'scatter',
+                color: 'black',
+                drawLines: true,
+                drawPoints: false,
+                strokeWidth: 1,
+              },
+            ]}
+            xAccessor={d => +d.x}
+            yAccessor={d => +d.y}
+          >
+            <Scatterplot zoomable />
+          </DataProvider>
+        </div>
+      </div>
+    </React.Fragment>
   ));


### PR DESCRIPTION
Through the use of a new `drawLines` prop, allow lines to be rendered on
scatterplots. This is shared between line charts and scatterplots, and
has different defaults -- on line charts, it will default to true, but
it will default to false on scatterplots.