### PR TITLE
Only show points that are within the timeSubDomain

### DIFF
--- a/src/components/PointCollection/index.js
+++ b/src/components/PointCollection/index.js
@@ -33,7 +33,25 @@ const PointCollection = ({
       Axes.y(subDomainsByItemId[s.collectionId || s.id]),
       height
     );
-    return <Points key={s.id} {...s} xScale={xScale} yScale={yScale} />;
+    // Only show points which are relevant for the current time subdomain.
+    // We don't need to do this for lines because we want lines to be drawn to
+    // infinity so that they go to the ends of the graph, but points are special
+    // since they can overlap in the [x,y] plane, but not be in the current time
+    // subdomain.
+    const pointFilter = d => {
+      const timestamp = s.timeAccessor(d);
+      const subDomain = Axes.time(subDomainsByItemId[s.id]);
+      return subDomain[0] <= timestamp && timestamp <= subDomain[1];
+    };
+    return (
+      <Points
+        key={s.id}
+        {...s}
+        xScale={xScale}
+        yScale={yScale}
+        pointFilter={pointFilter}
+      />
+    );
   });
 
   return (

--- a/src/components/Points/index.js
+++ b/src/components/Points/index.js
@@ -20,6 +20,7 @@ const propTypes = {
   color: PropTypes.string.isRequired,
   opacity: PropTypes.number,
   opacityAccessor: PropTypes.func,
+  pointFilter: PropTypes.func,
   pointWidth: PropTypes.number,
   pointWidthAccessor: PropTypes.func,
   strokeWidth: PropTypes.number,
@@ -27,6 +28,7 @@ const propTypes = {
 const defaultProps = {
   opacity: 1,
   opacityAccessor: null,
+  pointFilter: () => true,
   pointWidth: null,
   pointWidthAccessor: null,
   strokeWidth: null,
@@ -49,13 +51,14 @@ const Points = ({
   color,
   opacity,
   opacityAccessor,
+  pointFilter,
   pointWidth,
   pointWidthAccessor,
   strokeWidth,
 }) => {
   const getX = x => boundedSeries(xScale(x));
   const getY = y => boundedSeries(yScale(y));
-  const points = data.map(d => {
+  const points = data.filter(pointFilter).map(d => {
     let width = 0;
     if (pointWidthAccessor) {
       width = pointWidthAccessor(d);

--- a/stories/Scatterplot.stories.js
+++ b/stories/Scatterplot.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import 'react-select/dist/react-select.css';
 import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import moment from 'moment';
 import { DataProvider, Scatterplot, AxisPlacement, ContextChart } from '../src';
 import { staticLoader, functionLoader } from './loaders';
@@ -26,6 +27,7 @@ const mapping = {
 const NUM_POINTS = 50;
 
 const scatterplotloader = ({ id, reason, oldSeries, ...params }) => {
+  action('scatterplotloader')(reason);
   if (reason === 'MOUNTED') {
     const pair = mapping[id] || Math.round(Math.random() * 100);
     const { x, y } = {
@@ -88,6 +90,7 @@ const scatterplotFunctionLoader = ({
   timeSubDomain,
   ...params
 }) => {
+  action('scatterplotFunctionLoader')(reason);
   const dt = timeDomain[1] - timeDomain[0];
   const pair = mapping[id];
   const { x, y } = {
@@ -107,7 +110,7 @@ const scatterplotFunctionLoader = ({
     }),
   };
 
-  const data = [];
+  const newData = [];
   const lastKnown = { x: undefined, y: undefined, timestamp: undefined };
   while (x.data.length || y.data.length) {
     const points = {
@@ -129,11 +132,16 @@ const scatterplotFunctionLoader = ({
       lastKnown.y !== undefined &&
       lastKnown.timestamp !== undefined
     ) {
-      data.push({
+      newData.push({
         ...lastKnown,
       });
     }
   }
+
+  const data = []
+    .concat(oldSeries.data.filter(d => d.timestamp <= timeSubDomain[0]))
+    .concat(newData)
+    .concat(oldSeries.data.filter(d => d.timestamp >= timeSubDomain[1]));
 
   return { data };
 };


### PR DESCRIPTION
Apply a filter before rendering the points so that only points relevant
to the time subdomain (visible time range) are rendered. This allows for
similar behavior to the line chart where changing the time subdomain
shows the low-resolution aggregates before the loader renders the
higher-resolution data.