### PR TITLE
Pass extra params to the accessors

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -698,9 +698,11 @@ DataProvider.propTypes = {
   // xSubDomain => void
   onTimeSubDomainChanged: PropTypes.func,
   opacity: PropTypes.number,
+  /** (datapoint, index, datapoints) => number */
   opacityAccessor: PropTypes.func,
 
   pointWidth: PropTypes.number,
+  /** (datapoint, index, datapoints) => number */
   pointWidthAccessor: PropTypes.func,
   strokeWidth: PropTypes.number,
   // if set to true and an updateInterval is provided, xSubDomain

--- a/src/components/Points/index.js
+++ b/src/components/Points/index.js
@@ -68,17 +68,17 @@ const Points = ({
       xAccessor,
       x0Accessor || defaultMinMaxAccessor,
       x1Accessor || defaultMinMaxAccessor,
-    ].map(f => boundedSeries(xScale(f(d))));
+    ].map(f => +boundedSeries(xScale(f(d))));
 
     const [y, y0, y1] = [
       yAccessor,
       y0Accessor || defaultMinMaxAccessor,
       y1Accessor || defaultMinMaxAccessor,
-    ].map(f => boundedSeries(yScale(f(d))));
+    ].map(f => +boundedSeries(yScale(f(d))));
 
     let width = 0;
     if (pointWidthAccessor) {
-      width = pointWidthAccessor(d);
+      width = pointWidthAccessor(d, i, arr);
     } else if (pointWidth !== undefined && pointWidth !== null) {
       width = pointWidth;
     } else if (strokeWidth !== undefined && strokeWidth !== null) {
@@ -91,7 +91,7 @@ const Points = ({
     if (!Number.isNaN(x0) && !Number.isNaN(x1)) {
       uiElements.push(
         <line
-          key={`${x0},${y}-${x1},${y}`}
+          key={`horizontal-${x0},${y}-${x1},${y}`}
           x1={x0}
           y1={y}
           x2={x1}
@@ -105,7 +105,7 @@ const Points = ({
     if (!Number.isNaN(y0) && !Number.isNaN(y1)) {
       uiElements.push(
         <line
-          key={`${x},${y0}-${x},${y1}`}
+          key={`vertical-${x},${y0}-${x},${y1}`}
           x1={x}
           y1={y0}
           x2={x}
@@ -116,17 +116,19 @@ const Points = ({
       );
     }
 
-    uiElements.push(
-      <circle
-        key={`${x}-${y}`}
-        className="point"
-        r={width / 2}
-        opacity={opacityAccessor ? opacityAccessor(d) : opacity}
-        cx={x}
-        cy={y}
-        fill={color}
-      />
-    );
+    if (!Number.isNaN(x) && !Number.isNaN(y)) {
+      uiElements.push(
+        <circle
+          key={`${x}-${y}`}
+          className="point"
+          r={width / 2}
+          opacity={opacityAccessor ? opacityAccessor(d, i, arr) : opacity}
+          cx={x}
+          cy={y}
+          fill={color}
+        />
+      );
+    }
 
     if (typeof drawPoints === 'function') {
       const metadata = {

--- a/stories/Scatterplot.stories.js
+++ b/stories/Scatterplot.stories.js
@@ -577,7 +577,7 @@ storiesOf('Scatterplot', module)
           ]}
           xAccessor={d => +d.x}
           yAccessor={d => +d.y}
-          opacityAccessor={d => (+d.x + +d.y) / 2}
+          opacityAccessor={(d, i, arr) => (i / arr.length) * 0.9 + 0.1}
           pointWidth={20}
         >
           <Scatterplot zoomable />


### PR DESCRIPTION
When rendering the items with accessor functions, pass them information
about the index & data collection.

This change also forces the positions (x, y) to be numbers so that NaN
will be correctly identified and handled.