### PR TITLE
better support ruler positioning for multiple series

### DIFF
--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -297,24 +297,28 @@ class LineChart extends Component {
               width={chartSize.width}
               pointWidth={pointWidth}
             />
-            <InteractionLayer
-              height={chartSize.height}
-              width={chartSize.width}
-              crosshair={crosshair}
-              onMouseMove={onMouseMove}
-              onMouseOut={onMouseOut}
-              onBlur={onBlur}
-              onClickAnnotation={onClickAnnotation}
-              onDoubleClick={onDoubleClick}
-              ruler={ruler}
-              annotations={annotations}
-              onClick={onClick}
-              areas={areas}
-              onAreaDefined={onAreaDefined}
-              onZoomXAxis={onZoomXAxis}
-              onAreaClicked={onAreaClicked}
-              zoomAxes={{ time: zoomable }}
-            />
+            {// sizeMe can cause chartSize.width to be < 0, which causes
+            // problems for the position of the ruler in InteractionLayer
+            chartSize.width > 0 && (
+              <InteractionLayer
+                height={chartSize.height}
+                width={chartSize.width}
+                crosshair={crosshair}
+                onMouseMove={onMouseMove}
+                onMouseOut={onMouseOut}
+                onBlur={onBlur}
+                onClickAnnotation={onClickAnnotation}
+                onDoubleClick={onDoubleClick}
+                ruler={ruler}
+                annotations={annotations}
+                onClick={onClick}
+                areas={areas}
+                onAreaDefined={onAreaDefined}
+                onZoomXAxis={onZoomXAxis}
+                onAreaClicked={onAreaClicked}
+                zoomAxes={{ time: zoomable }}
+              />
+            )}
           </svg>
         }
         yAxis={


### PR DESCRIPTION
a few fixes here:
1. don't add a `rulerPoint` if there is no data for that series
1. don't attempt to add a `rulerPoint` if there is no entry in `subDomainsByItemId` for the series. (This can happen when a new series is added but an entry for it has not yet been added to `subDomainsByItemId`)
1. update the ruler position on width change and `subDomainsByItemId` change
1.  don't render `InteractionLayer` if its width will be < 0 (this occurs when sizeMe returns a width of 0 for `LineChart`. this is done because otherwise, the calculated xposition for the ruler will be < 0, causing it to be cleared.