### PR TITLE
Respect the loader's control over drawPoints

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -331,11 +331,13 @@ export default class DataProvider extends Component {
       ...deleteUndefinedFromObject(loaderConfig[series.id]),
       ...deleteUndefinedFromObject(series),
       drawPoints: firstDefined(
+        (loaderConfig[series.id] || {}).drawPoints,
         series.drawPoints,
         collection.drawPoints,
         drawPoints
       ),
       drawLines: firstDefined(
+        (loaderConfig[series.id] || {}).drawLines,
         series.drawLines,
         collection.drawLines,
         drawLines


### PR DESCRIPTION
The loader is often the best source of whether or not to draw the points
on the rendered line. As such, its input should be given top priority
when deciding whether or not the series will have its points drawn.

The same logic applies to drawLines, too.