### PR TITLE
Rework domains & subdomains for x & y axes

### DIFF
--- a/src/components/LineCollection/index.js
+++ b/src/components/LineCollection/index.js
@@ -19,9 +19,9 @@ const LineCollection = props => {
     height,
     xAxis,
     xScalerFactory,
+    yScalerFactory,
     pointWidth,
     scaleX,
-    scaleY,
   } = props;
   if (!subDomainsByItemId) {
     return null;
@@ -35,6 +35,12 @@ const LineCollection = props => {
         }`
     )
     .join('/')}`;
+
+  const yScaler =
+    yScalerFactory ||
+    ((s, h) =>
+      createYScale(Axes.y(subDomainsByItemId[s.collectionId || s.id]), h));
+
   const lines = series.reduce((l, s) => {
     if (s.hidden) {
       return l;
@@ -44,10 +50,7 @@ const LineCollection = props => {
       scaleX ? xAxis(subDomainsByItemId[id]) : xAxis(domainsByItemId[id]),
       width
     );
-    const yScale = createYScale(
-      scaleY ? Axes.y(subDomainsByItemId[s.collectionId || s.id]) : s.yDomain,
-      height
-    );
+    const yScale = yScaler(s, height);
     return [
       ...l,
       <Line
@@ -78,11 +81,9 @@ LineCollection.propTypes = {
   series: seriesPropType,
   pointWidth: PropTypes.number,
   scaleX: PropTypes.bool,
-  // Perform Y-scaling based on the current subdomain. If false, then use the
-  // static yDomain property.
-  scaleY: PropTypes.bool,
 
   // These are provided by Griff
+  yScalerFactory: scalerFactoryFunc,
   xScalerFactory: scalerFactoryFunc.isRequired,
   domainsByItemId: GriffPropTypes.domainsByItemId.isRequired,
   subDomainsByItemId: GriffPropTypes.subDomainsByItemId.isRequired,
@@ -92,8 +93,8 @@ LineCollection.defaultProps = {
   series: [],
   pointWidth: 6,
   scaleX: true,
-  scaleY: true,
   xAxis: Axes.time,
+  yScalerFactory: null,
 };
 
 export default props => (
@@ -101,8 +102,8 @@ export default props => (
     {({ domainsByItemId, subDomainsByItemId, series, xScalerFactory }) => (
       <LineCollection
         series={series}
-        {...props}
         xScalerFactory={xScalerFactory}
+        {...props}
         domainsByItemId={domainsByItemId}
         subDomainsByItemId={subDomainsByItemId}
       />

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -17,17 +17,34 @@ const FRONT_OF_WINDOW_THRESHOLD = 0.05;
  */
 export const PLACEHOLDER_DOMAIN = [0, 0];
 
-const containsSameItems = (a, b) => {
-  const reducer = (acc, item) => {
-    if (item.hidden) {
-      return acc;
+const haveDomainsChanged = (before, after) =>
+  before.timeDomain !== after.timeDomain ||
+  before.timeSubDomain !== after.timeSubDomain ||
+  before.xDomain !== after.xDomain ||
+  before.xSubDomain !== after.xSubDomain ||
+  before.yDomain !== after.yDomain ||
+  before.ySubDomain !== after.ySubDomain;
+
+const findItemsWithChangedDomains = (previousItems, currentItems) => {
+  const previousItemsById = previousItems.reduce(
+    (acc, s) => ({
+      ...acc,
+      [s.id]: s,
+    }),
+    {}
+  );
+  return currentItems.reduce((acc, s) => {
+    if (
+      !previousItemsById[s.id] ||
+      haveDomainsChanged(previousItemsById[s.id] || {}, s)
+    ) {
+      return [...acc, s];
     }
-    return { ...acc, [item.id]: item.yDomain };
-  };
-  return isEqual(a.reduce(reducer, {}), b.reduce(reducer, {}));
+    return acc;
+  }, []);
 };
 
-const stripPlaceholderDomain = domain => {
+export const stripPlaceholderDomain = domain => {
   if (isEqual(PLACEHOLDER_DOMAIN, domain)) {
     return undefined;
   }
@@ -41,7 +58,7 @@ const stripPlaceholderDomain = domain => {
  * are three axes:
  *   time: The timestamp of a datapoint
  *   x: The x-value of a datapoint
- *   y: THe y-value of a datapoint.
+ *   y: The y-value of a datapoint.
  *
  * These axes all have separate domains and subdomains. The domain is the range
  * of that axis, and the subdomain is the currently-visible region of that
@@ -83,53 +100,67 @@ class Scaler extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (
-      !containsSameItems(
-        prevProps.dataContext.series,
-        this.props.dataContext.series
-      )
-    ) {
-      const domainsByItemId = {};
-      const subDomainsByItemId = {};
+    const changedSeries = findItemsWithChangedDomains(
+      prevProps.dataContext.series,
+      this.props.dataContext.series
+    );
+    const changedCollections = findItemsWithChangedDomains(
+      prevProps.dataContext.collections,
+      this.props.dataContext.collections
+    );
+    if (changedSeries.length > 0 || changedCollections.length > 0) {
+      const domainsByItemId = { ...this.state.domainsByItemId };
+      const subDomainsByItemId = { ...this.state.subDomainsByItemId };
 
-      const updateDomainsForItem = item => {
-        domainsByItemId[item.id] = {
-          [Axes.time]: this.props.dataContext.timeDomain || [
-            ...(stripPlaceholderDomain(
-              Axes.time(this.state.domainsByItemId[item.id])
-            ) || item.timeDomain),
-          ],
-          [Axes.x]: [
-            ...(stripPlaceholderDomain(
-              Axes.x(this.state.domainsByItemId[item.id])
-            ) || item.xDomain),
-          ],
-          [Axes.y]: [
-            ...(stripPlaceholderDomain(
-              Axes.y(this.state.domainsByItemId[item.id])
-            ) || item.yDomain),
-          ],
-        };
-        subDomainsByItemId[item.id] = {
-          [Axes.time]: this.props.dataContext.timeSubDomain || [
-            ...(stripPlaceholderDomain(
-              Axes.time(this.state.subDomainsByItemId[item.id])
-            ) || item.timeSubDomain),
-          ],
-          [Axes.x]: [
-            ...(stripPlaceholderDomain(
-              Axes.x(this.state.subDomainsByItemId[item.id])
-            ) || item.xSubDomain),
-          ],
-          [Axes.y]: [
-            ...(stripPlaceholderDomain(
-              Axes.y(this.state.subDomainsByItemId[item.id])
-            ) || item.ySubDomain),
-          ],
-        };
-      };
-      (this.props.dataContext.series || []).forEach(updateDomainsForItem);
-      (this.props.dataContext.collections || []).forEach(updateDomainsForItem);
+      []
+        .concat(changedSeries)
+        .concat(changedCollections)
+        .forEach(item => {
+          domainsByItemId[item.id] = {
+            [Axes.time]: this.props.dataContext.timeDomain || [
+              ...(item.timeDomain ||
+                stripPlaceholderDomain(
+                  Axes.time(this.state.domainsByItemId[item.id])
+                )),
+            ],
+            [Axes.x]: [
+              ...(item.xDomain ||
+                stripPlaceholderDomain(
+                  Axes.x(this.state.domainsByItemId[item.id])
+                ) ||
+                PLACEHOLDER_DOMAIN),
+            ],
+            [Axes.y]: [
+              ...(item.yDomain ||
+                stripPlaceholderDomain(
+                  Axes.y(this.state.domainsByItemId[item.id])
+                ) ||
+                PLACEHOLDER_DOMAIN),
+            ],
+          };
+          subDomainsByItemId[item.id] = {
+            [Axes.time]: this.props.dataContext.timeSubDomain || [
+              ...(item.timeSubDomain ||
+                stripPlaceholderDomain(
+                  Axes.time(this.state.subDomainsByItemId[item.id])
+                )),
+            ],
+            [Axes.x]: [
+              ...(item.xSubDomain ||
+                stripPlaceholderDomain(
+                  Axes.x(this.state.subDomainsByItemId[item.id])
+                ) ||
+                PLACEHOLDER_DOMAIN),
+            ],
+            [Axes.y]: [
+              ...(item.ySubDomain ||
+                stripPlaceholderDomain(
+                  Axes.y(this.state.subDomainsByItemId[item.id])
+                ) ||
+                PLACEHOLDER_DOMAIN),
+            ],
+          };
+        });
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ subDomainsByItemId, domainsByItemId });
       return;
@@ -208,8 +239,8 @@ class Scaler extends Component {
           ...acc,
           [item.id]: {
             [Axes.time]: [...this.props.dataContext.timeDomain],
-            [Axes.x]: [...(item.xDomain || [])],
-            [Axes.y]: [...(item.yDomain || [])],
+            [Axes.x]: [...(item.xDomain || PLACEHOLDER_DOMAIN)],
+            [Axes.y]: [...(item.yDomain || PLACEHOLDER_DOMAIN)],
           },
         }),
         {}
@@ -224,8 +255,8 @@ class Scaler extends Component {
           ...acc,
           [item.id]: {
             [Axes.time]: [...this.props.dataContext.timeSubDomain],
-            [Axes.x]: [...(item.xDomain || item.xSubDomain || [])],
-            [Axes.y]: [...(item.yDomain || item.ySubDomain || [])],
+            [Axes.x]: [...(item.xSubDomain || PLACEHOLDER_DOMAIN)],
+            [Axes.y]: [...(item.ySubDomain || PLACEHOLDER_DOMAIN)],
           },
         }),
         {}
@@ -253,7 +284,7 @@ class Scaler extends Component {
     // FIXME: This is not multi-series aware.
     let newTimeSubDomain = null;
 
-    const { domainsById, subDomainsByItemId } = this.state;
+    const { domainsByItemId, subDomainsByItemId } = this.state;
     const newSubDomains = { ...subDomainsByItemId };
     Object.keys(changedDomainsById).forEach(itemId => {
       newSubDomains[itemId] = { ...(subDomainsByItemId[itemId] || {}) };
@@ -271,11 +302,13 @@ class Scaler extends Component {
           subDomainsByItemId[itemId][axis] || newSubDomain;
         const existingSpan = existingSubDomain[1] - existingSubDomain[0];
 
-        const limits = ((domainsById || {})[itemId] || {})[axis] ||
-          (axis === String(Axes.time)
-            ? // FIXME: Phase out this single timeDomain thing.
-              this.props.dataContext.timeDomain
-            : undefined) || [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER];
+        const limits = stripPlaceholderDomain(
+          ((domainsByItemId || {})[itemId] || {})[axis] ||
+            (axis === String(Axes.time)
+              ? // FIXME: Phase out this single timeDomain thing.
+                this.props.dataContext.timeDomain
+              : undefined)
+        ) || [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER];
 
         if (newSpan === existingSpan) {
           // This is a translation; check the bounds.

--- a/src/context/Data.js
+++ b/src/context/Data.js
@@ -5,5 +5,4 @@ export default React.createContext({
   collections: [],
   xDomain: [Date.now() - 1000 * 60 * 60 * 24 * 365, 0],
   yAxisWidth: 50,
-  contextSeries: [],
 });

--- a/stories/LineChart.stories.js
+++ b/stories/LineChart.stories.js
@@ -40,7 +40,7 @@ storiesOf('LineChart', module)
       defaultLoader={staticLoader}
       timeDomain={staticXDomain}
       series={[
-        { id: 1, color: 'steelblue', ySubDomain: [0, 2] },
+        { id: 1, color: 'steelblue', ySubDomain: [0, 5] },
         { id: 2, color: 'maroon', ySubDomain: [-1, 1] },
       ]}
     >
@@ -376,9 +376,11 @@ storiesOf('LineChart', module)
     return <HiddenSeries />;
   })
   .add('Specify y domain', () => {
-    const staticDomain = [-2, 2];
+    const staticDomain = [-5, 5];
+    const staticSubDomain = [-2, 2];
+
     class SpecifyDomain extends React.Component {
-      state = { yDomains: {} };
+      state = { yDomains: {}, ySubDomains: {} };
 
       setStaticDomain = key => {
         const { yDomains } = this.state;
@@ -393,25 +395,56 @@ storiesOf('LineChart', module)
         this.setState({ yDomains: { ...yDomains, [key]: staticDomain } });
       };
 
+      setStaticSubDomain = key => {
+        const { ySubDomains } = this.state;
+        if (ySubDomains[key]) {
+          const newYSubDomains = { ...ySubDomains };
+          delete newYSubDomains[key];
+          this.setState({ ySubDomains: newYSubDomains });
+          action(`Removing static domain`)(key);
+          return;
+        }
+        action(`Setting subdomain to DataProvider`)(key);
+        this.setState({
+          ySubDomains: { ...ySubDomains, [key]: staticSubDomain },
+        });
+      };
+
       render() {
-        const { yDomains } = this.state;
+        const { yDomains, ySubDomains } = this.state;
         return (
           <React.Fragment>
             <DataProvider
               defaultLoader={staticLoader}
               timeDomain={staticXDomain}
               series={[
-                { id: 1, color: 'steelblue', yDomain: yDomains[1] },
-                { id: 2, color: 'maroon', yDomain: yDomains[2] },
+                {
+                  id: 1,
+                  color: 'steelblue',
+                  yDomain: yDomains[1],
+                  ySubDomain: ySubDomains[1],
+                },
+                {
+                  id: 2,
+                  color: 'maroon',
+                  yDomain: yDomains[2],
+                  ySubDomain: ySubDomains[2],
+                },
               ]}
             >
               <LineChart height={CHART_HEIGHT} />
             </DataProvider>
             <button onClick={() => this.setStaticDomain(1)}>
-              Static series 1
+              Set blue domain
+            </button>
+            <button onClick={() => this.setStaticSubDomain(1)}>
+              Set blue subdomain
             </button>
             <button onClick={() => this.setStaticDomain(2)}>
-              Static series 2
+              Set maroon domain
+            </button>
+            <button onClick={() => this.setStaticSubDomain(2)}>
+              Set maroon subdomain
             </button>
           </React.Fragment>
         );
@@ -629,7 +662,11 @@ storiesOf('LineChart', module)
   })
   .add('ySubDomain', () => (
     <React.Fragment>
-      <h1>Set on DataProvider</h1>
+      <h1>Set on DataProvider ([0.25, 0.5])</h1>
+      <p>
+        The ySubDomain for the chart should be [0.25, 0.5]. The context chart
+        should be [0,1].
+      </p>
       <DataProvider
         defaultLoader={staticLoader}
         timeDomain={staticXDomain}
@@ -639,6 +676,10 @@ storiesOf('LineChart', module)
         <LineChart height={CHART_HEIGHT} />
       </DataProvider>
       <h1>Set on Series</h1>
+      <p>
+        The ySubDomain for the chart should be [0.25, 0.5] for blue{' '}
+        <em>only</em>. Maroon should be [0, 1]
+      </p>
       <DataProvider
         defaultLoader={staticLoader}
         timeDomain={staticXDomain}
@@ -650,6 +691,10 @@ storiesOf('LineChart', module)
         <LineChart height={CHART_HEIGHT} />
       </DataProvider>
       <h1>Set on Collection</h1>
+      <p>
+        The ySubDomain for the chart should be [0.0, 0.5] for the green
+        collection (includes all lines).
+      </p>
       <DataProvider
         defaultLoader={staticLoader}
         timeDomain={staticXDomain}
@@ -668,8 +713,9 @@ storiesOf('LineChart', module)
       </DataProvider>
       <h1>Set on Series with yDomain</h1>
       <p>
-        The LineChart should be zoomed-in, but the context chart should be
-        zoomed-out
+        The LineChart should be zoomed-in for the blue line, but the context
+        chart should be zoomed-out (for the blue line). The blue line should
+        have a maximum zoom-out range of [-1, 2].
       </p>
       <DataProvider
         defaultLoader={staticLoader}


### PR DESCRIPTION
Make x & y domains behave like time: if there is a domain specified,
then the subdomain cannot go beyond those bounds. If neither are
specified, then the subdomain will default to the extent of the data
(with an open-ended domain).

This also removes the notion of a contextSeries. Instead, have the
context chart (if present) simply transform the series to look how it
wants them to look (static domains, drawPoints=false, etc).

This change also introduces an unconsistency: LineCollection takes in a
yScalerFactory with a different signature than xScalerFactory. This will
be cleaned up in a fast-follow PR (to move xScalerFactory to the same
signature as the new yScalerFactory). This refactor was omitted from
this PR to keep it manageable.