### PR TITLE
Correctly determine axes for AxisCollection

### DIFF
--- a/src/components/AxisCollection/index.js
+++ b/src/components/AxisCollection/index.js
@@ -111,16 +111,11 @@ class AxisCollection extends React.Component {
       filteredCollections.reverse();
     }
 
-    const collectionsById = filteredCollections.reduce(
-      (acc, c) => ({ ...acc, [c.id]: true }),
-      {}
-    );
-
     const filteredSeries = series.filter(
       s =>
         this.axisFilter(AxisDisplayMode.ALL)(s) &&
         this.placementFilter(s) &&
-        (s.collectionId === undefined || !collectionsById[s.collectionId])
+        s.collectionId === undefined
     );
     if (yAxisPlacement === AxisPlacement.LEFT) {
       filteredSeries.reverse();

--- a/src/components/Scatterplot/index.js
+++ b/src/components/Scatterplot/index.js
@@ -55,6 +55,32 @@ const defaultProps = {
 const Y_AXIS_WIDTH = 50;
 const X_AXIS_HEIGHT = 50;
 
+const getYAxisPlacement = ({ collections, series, yAxisPlacement }) => {
+  const yAxisPlacements = []
+    .concat(series.filter(s => s.collectionId === undefined))
+    .concat(collections)
+    .reduce((acc, item) => {
+      const placement = item.yAxisPlacement || yAxisPlacement;
+      if (placement) {
+        acc[placement] = (acc[placement] || 0) + 1;
+      }
+      return acc;
+    }, {});
+  if (yAxisPlacements[AxisPlacement.BOTH]) {
+    return AxisPlacement.BOTH;
+  }
+  if (
+    yAxisPlacements[AxisPlacement.LEFT] &&
+    yAxisPlacements[AxisPlacement.RIGHT]
+  ) {
+    return AxisPlacement.BOTH;
+  }
+  if (yAxisPlacements[AxisPlacement.LEFT]) {
+    return AxisPlacement.LEFT;
+  }
+  return yAxisPlacement || AxisPlacement.RIGHT;
+};
+
 const ScatterplotComponent = ({
   collections,
   grid,
@@ -67,7 +93,7 @@ const ScatterplotComponent = ({
   xAxisTicks,
   xScalerFactory,
   yAxisFormatter,
-  yAxisPlacement,
+  yAxisPlacement: propsYAxisPlacement,
   yAxisTicks,
 }) => {
   const chartSize = {
@@ -107,14 +133,13 @@ const ScatterplotComponent = ({
     .concat(Object.values(collectionVisibility))
     .filter(Boolean).length;
 
-  switch (yAxisPlacement) {
-    case AxisPlacement.BOTH:
-      chartSize.width -= 2 * visibleAxes * Y_AXIS_WIDTH;
-      break;
-    default:
-      chartSize.width -= visibleAxes * Y_AXIS_WIDTH;
-      break;
-  }
+  const yAxisPlacement = getYAxisPlacement({
+    collections,
+    series,
+    propsYAxisPlacement,
+  });
+
+  chartSize.width -= visibleAxes * Y_AXIS_WIDTH;
 
   switch (xAxisPlacement) {
     case AxisPlacement.BOTH:

--- a/stories/Scatterplot.stories.js
+++ b/stories/Scatterplot.stories.js
@@ -469,6 +469,37 @@ storiesOf('Scatterplot', module)
       </div>
     </React.Fragment>
   ))
+  .add('Split axes', () => (
+    <div
+      style={{
+        width: '500px',
+        height: '500px',
+        outline: '1px solid red',
+        margin: '1em',
+      }}
+    >
+      <DataProvider
+        defaultLoader={scatterplotloader}
+        timeDomain={[0, 1]}
+        xDomain={[-1, 2]}
+        yDomain={[-1, 2]}
+        collections={[
+          { id: 'left', color: 'red', yAxisPlacement: AxisPlacement.LEFT },
+          { id: 'right', color: 'blue', yAxisPlacement: AxisPlacement.RIGHT },
+        ]}
+        series={[
+          { id: '1 2', collectionId: 'left', color: 'steelblue' },
+          { id: '2 3', collectionId: 'left', color: 'maroon' },
+          { id: '3 4', collectionId: 'right', color: 'black' },
+          { id: '4 5', collectionId: 'right', color: 'gray' },
+        ]}
+        xAccessor={d => +d.x}
+        yAccessor={d => +d.y}
+      >
+        <Scatterplot zoomable />
+      </DataProvider>
+    </div>
+  ))
   .add('Stroke width', () => (
     <React.Fragment>
       <div style={{ height: '500px', width: '500px' }}>


### PR DESCRIPTION
When there are collections which can be on either side of the chart,
AxisCollection needs to handle this correctly. Previously, the following
situation would arise:

Series:
  { id: 1, collectionId: 'left' }
  { id: 2, collectionId: 'left' }
  { id: 3, collectionId: 'right' }
  { id: 4, collectionId: 'right' }

Collections:
  { id: 'left' }
  { id: 'right' }

With this data set, the left axis would have the `left` collection, but
also series `3` and `4`. Similarly, the right axis would have `right`,
`1`, and `2`.