### PR TITLE
Allow drawing lines without time

### DIFF
--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -54,7 +54,7 @@ const Line = ({
   }
   let circles = null;
   if (drawPoints) {
-    const xSubDomain = xScale.domain().map(p => p.getTime());
+    const xSubDomain = xScale.domain().map(p => (p.getTime ? p.getTime() : p));
     circles = (
       <Points
         data={data.filter(d => {


### PR DESCRIPTION
The x domain is not necessarily time anymore, so don't make that
assumption when drawing lines. It's possible that this getTime() call
could be removed entirely, but it's unclear what the side-effects of
doing that would be. Instead, be safe and allow for a smoother
migration.