### PR TITLE
Remove xScalerFactory and createLinearXScale

### DIFF
--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -5,15 +5,12 @@ import ScalerContext from '../../context/Scaler';
 import LineCollection from '../LineCollection';
 import XAxis from '../XAxis';
 import Annotation from '../Annotation';
-import GriffPropTypes, {
-  annotationPropType,
-  scalerFactoryFunc,
-} from '../../utils/proptypes';
+import GriffPropTypes, { annotationPropType } from '../../utils/proptypes';
 import Brush from '../Brush';
 import AxisPlacement from '../AxisPlacement';
 import multiFormat from '../../utils/multiFormat';
 import Axes from '../../utils/Axes';
-import { createYScale } from '../../utils/scale-helpers';
+import { createYScale, createXScale } from '../../utils/scale-helpers';
 import { stripPlaceholderDomain } from '../Scaler';
 import { calculateDomainFromData } from '../DataProvider';
 
@@ -34,7 +31,6 @@ class ContextChart extends Component {
     timeDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
     timeSubDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
     updateDomains: GriffPropTypes.updateDomains.isRequired,
-    xScalerFactory: scalerFactoryFunc.isRequired,
     width: PropTypes.number,
   };
 
@@ -49,8 +45,8 @@ class ContextChart extends Component {
   };
 
   onUpdateSelection = selection => {
-    const { series, timeDomain, width, xScalerFactory } = this.props;
-    const xScale = xScalerFactory(timeDomain, width);
+    const { series, timeDomain, width } = this.props;
+    const xScale = createXScale(timeDomain, width);
     const timeSubDomain = selection.map(xScale.invert).map(Number);
     this.props.updateDomains(
       series.reduce(
@@ -104,7 +100,6 @@ class ContextChart extends Component {
       xAxisFormatter,
       xAxisHeight,
       xAxisPlacement,
-      xScalerFactory,
       zoomable,
     } = this.props;
 
@@ -112,7 +107,7 @@ class ContextChart extends Component {
     const timeDomain = Axes.time(domainsByItemId[firstItemId]);
     const timeSubDomain = Axes.time(subDomainsByItemId[firstItemId]);
     const height = this.getChartHeight();
-    const xScale = xScalerFactory(timeDomain, width);
+    const xScale = createXScale(timeDomain, width);
     const selection = timeSubDomain.map(xScale);
     const annotations = this.props.annotations.map(a => (
       <Annotation key={a.id} {...a} height={height} xScale={xScale} />
@@ -142,7 +137,6 @@ class ContextChart extends Component {
             series={series.map(s => ({ ...s, drawPoints: false }))}
             width={width}
             height={height}
-            xScalerFactory={xScalerFactory}
             yScalerFactory={this.getYScale}
             scaleY={false}
             scaleX={false}
@@ -169,7 +163,6 @@ export default props => (
       subDomainsByItemId,
       timeSubDomain,
       timeDomain,
-      xScalerFactory,
       updateDomains,
       series,
     }) => (
@@ -181,7 +174,6 @@ export default props => (
             {...props}
             timeDomain={timeDomain}
             timeSubDomain={timeSubDomain}
-            xScalerFactory={xScalerFactory}
             subDomainsByItemId={subDomainsByItemId}
             domainsByItemId={domainsByItemId}
             updateDomains={updateDomains}

--- a/src/components/GridLines/index.js
+++ b/src/components/GridLines/index.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ScalerContext from '../../context/Scaler';
-import GriffPropTypes, {
-  seriesPropType,
-  scalerFactoryFunc,
-} from '../../utils/proptypes';
+import GriffPropTypes, { seriesPropType } from '../../utils/proptypes';
 import { createYScale, createXScale } from '../../utils/scale-helpers';
 import Axes from '../../utils/Axes';
 
@@ -18,13 +15,11 @@ const propTypes = {
   }),
   // These are all populated by Griff.
   subDomainsByItemId: GriffPropTypes.subDomainsByItemId.isRequired,
-  xScalerFactory: scalerFactoryFunc,
 };
 
 const defaultProps = {
   axes: { x: 'x' },
   grid: null,
-  xScalerFactory: createXScale,
 };
 
 const DEFAULT_COLOR = '#666';
@@ -40,7 +35,6 @@ class GridLines extends React.Component {
       width,
       series,
       subDomainsByItemId,
-      xScalerFactory,
       axes,
     } = this.props;
 
@@ -168,7 +162,7 @@ class GridLines extends React.Component {
         // FIXME: Remove this when we support multiple X axes
         const timeSubDomain =
           subDomainsByItemId[Object.keys(subDomainsByItemId)[0]][axes.x];
-        const scale = xScalerFactory(timeSubDomain, width);
+        const scale = createXScale(timeSubDomain, width);
         const values = scale.ticks(x.ticks || Math.floor(width / 100) || 1);
         values.forEach(v => {
           lines.push(
@@ -225,12 +219,11 @@ GridLines.defaultProps = defaultProps;
 
 export default props => (
   <ScalerContext.Consumer>
-    {({ series, subDomainsByItemId, xScalerFactory }) => (
+    {({ series, subDomainsByItemId }) => (
       <GridLines
         {...props}
         series={series}
         subDomainsByItemId={subDomainsByItemId}
-        xScalerFactory={xScalerFactory}
       />
     )}
   </ScalerContext.Consumer>

--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -54,7 +54,7 @@ const Line = ({
   }
   let circles = null;
   if (drawPoints) {
-    const xSubDomain = xScale.domain().map(p => (p.getTime ? p.getTime() : p));
+    const xSubDomain = xScale.domain();
     circles = (
       <Points
         data={data.filter(d => {

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -11,7 +11,6 @@ import GriffPropTypes, {
   annotationPropType,
   rulerPropType,
   axisDisplayModeType,
-  scalerFactoryFunc,
 } from '../../utils/proptypes';
 import LineCollection from '../LineCollection';
 import InteractionLayer from '../InteractionLayer';
@@ -19,7 +18,6 @@ import XAxis from '../XAxis';
 import AxisDisplayMode from './AxisDisplayMode';
 import AxisPlacement from '../AxisPlacement';
 import Layout from './Layout';
-import { createXScale } from '../../utils/scale-helpers';
 import multiFormat from '../../utils/multiFormat';
 
 const propTypes = {
@@ -63,7 +61,6 @@ const propTypes = {
   onAxisMouseEnter: PropTypes.func,
   // (e, seriesId) => void
   onAxisMouseLeave: PropTypes.func,
-  xScalerFactory: scalerFactoryFunc,
   areas: PropTypes.arrayOf(areaPropType),
   /**
    * Pass in a callback function which will be given a defined area when the
@@ -117,7 +114,6 @@ const defaultProps = {
   xSubDomain: [],
   xAxisFormatter: multiFormat,
   xAxisPlacement: AxisPlacement.BOTTOM,
-  xScalerFactory: createXScale,
   yAxisDisplayMode: AxisDisplayMode.ALL,
   yAxisFormatter: Number,
   yAxisPlacement: AxisPlacement.RIGHT,
@@ -252,7 +248,6 @@ class LineChart extends Component {
       xSubDomain,
       ruler,
       width: propWidth,
-      xScalerFactory,
       xAxisHeight,
       xAxisFormatter,
       xAxisPlacement,
@@ -334,7 +329,6 @@ class LineChart extends Component {
         xAxis={
           <XAxis
             domain={xSubDomain}
-            xScalerFactory={xScalerFactory}
             height={xAxisHeight}
             placement={xAxisPlacement}
             tickFormatter={xAxisFormatter}
@@ -363,13 +357,12 @@ const SizedLineChart = sizeMe({ monitorHeight: true })(LineChart);
 
 export default props => (
   <ScalerContext.Consumer>
-    {({ collections, series, xSubDomain, xScalerFactory, yAxisWidth }) => (
+    {({ collections, series, xSubDomain, yAxisWidth }) => (
       <SizedLineChart
         {...props}
         collections={collections}
         series={series}
         timeSubDomain={xSubDomain}
-        xScalerFactory={xScalerFactory}
         yAxisWidth={yAxisWidth}
       />
     )}

--- a/src/components/LineCollection/index.js
+++ b/src/components/LineCollection/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { createYScale } from '../../utils/scale-helpers';
+import { createXScale, createYScale } from '../../utils/scale-helpers';
 import GriffPropTypes, {
   seriesPropType,
   scalerFactoryFunc,
@@ -18,7 +18,6 @@ const LineCollection = props => {
     width,
     height,
     xAxis,
-    xScalerFactory,
     yScalerFactory,
     pointWidth,
     scaleX,
@@ -46,7 +45,7 @@ const LineCollection = props => {
       return l;
     }
     const { id } = s;
-    const xScale = xScalerFactory(
+    const xScale = createXScale(
       scaleX ? xAxis(subDomainsByItemId[id]) : xAxis(domainsByItemId[id]),
       width
     );
@@ -84,7 +83,6 @@ LineCollection.propTypes = {
 
   // These are provided by Griff
   yScalerFactory: scalerFactoryFunc,
-  xScalerFactory: scalerFactoryFunc.isRequired,
   domainsByItemId: GriffPropTypes.domainsByItemId.isRequired,
   subDomainsByItemId: GriffPropTypes.subDomainsByItemId.isRequired,
 };
@@ -99,10 +97,9 @@ LineCollection.defaultProps = {
 
 export default props => (
   <ScalerContext.Consumer>
-    {({ domainsByItemId, subDomainsByItemId, series, xScalerFactory }) => (
+    {({ domainsByItemId, subDomainsByItemId, series }) => (
       <LineCollection
         series={series}
-        xScalerFactory={xScalerFactory}
         {...props}
         domainsByItemId={domainsByItemId}
         subDomainsByItemId={subDomainsByItemId}

--- a/src/components/PointCollection/index.js
+++ b/src/components/PointCollection/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ScalerContext from '../../context/Scaler';
-import { createYScale } from '../../utils/scale-helpers';
+import { createYScale, createXScale } from '../../utils/scale-helpers';
 import Points from '../Points';
 import GriffPropTypes, { seriesPropType } from '../../utils/proptypes';
 import Axes from '../../utils/Axes';
@@ -11,18 +11,10 @@ const propTypes = {
   height: PropTypes.number.isRequired,
   series: seriesPropType.isRequired,
   subDomainsByItemId: GriffPropTypes.subDomainsByItemId.isRequired,
-  // (domain, width) => [number, number]
-  xScalerFactory: PropTypes.func.isRequired,
 };
 const defaultProps = {};
 
-const PointCollection = ({
-  width,
-  height,
-  series,
-  subDomainsByItemId,
-  xScalerFactory,
-}) => {
+const PointCollection = ({ width, height, series, subDomainsByItemId }) => {
   const points = series
     .filter(s => !s.hidden && s.drawPoints !== false)
     .map(s => {
@@ -30,7 +22,7 @@ const PointCollection = ({
       // entirely sure why; I think it's because the collection's x domain is not
       // correctly calculated to the data's extent. I have not looked into it
       // because it doesn't really matter yet, but it will at some point.
-      const xScale = xScalerFactory(Axes.x(subDomainsByItemId[s.id]), width);
+      const xScale = createXScale(Axes.x(subDomainsByItemId[s.id]), width);
       const yScale = createYScale(
         Axes.y(subDomainsByItemId[s.collectionId || s.id]),
         height
@@ -53,12 +45,11 @@ PointCollection.defaultProps = defaultProps;
 
 export default props => (
   <ScalerContext.Consumer>
-    {({ subDomainsByItemId, series, xScalerFactory }) => (
+    {({ subDomainsByItemId, series }) => (
       <PointCollection
         {...props}
         series={series}
         subDomainsByItemId={subDomainsByItemId}
-        xScalerFactory={xScalerFactory}
       />
     )}
   </ScalerContext.Consumer>

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import isEqual from 'lodash.isequal';
 import DataContext from '../../context/Data';
 import ScalerContext from '../../context/Scaler';
-import { createXScale } from '../../utils/scale-helpers';
 import GriffPropTypes, { seriesPropType } from '../../utils/proptypes';
 import Axes from '../../utils/Axes';
 
@@ -79,13 +78,9 @@ class Scaler extends Component {
       series: seriesPropType.isRequired,
       collections: GriffPropTypes.collections.isRequired,
     }).isRequired,
-    // (domain, width) => [number, number]
-    xScalerFactory: PropTypes.func,
   };
 
-  static defaultProps = {
-    xScalerFactory: createXScale,
-  };
+  static defaultProps = {};
 
   constructor(props) {
     super(props);
@@ -343,7 +338,7 @@ class Scaler extends Component {
 
   render() {
     const { domainsByItemId, subDomainsByItemId } = this.state;
-    const { dataContext, xScalerFactory } = this.props;
+    const { dataContext } = this.props;
     const ownContext = {
       updateDomains: this.updateDomains,
       domainsByItemId,
@@ -352,7 +347,6 @@ class Scaler extends Component {
 
     const enrichedContext = {
       timeSubDomain: dataContext.timeSubDomain || dataContext.timeDomain,
-      xScalerFactory,
     };
 
     const finalContext = {

--- a/src/components/Scatterplot/index.js
+++ b/src/components/Scatterplot/index.js
@@ -5,11 +5,7 @@ import Scaler from '../Scaler';
 import ScalerContext from '../../context/Scaler';
 import PointCollection from '../PointCollection';
 import InteractionLayer, { ZoomMode } from '../InteractionLayer';
-import { createLinearXScale } from '../../utils/scale-helpers';
-import GriffPropTypes, {
-  seriesPropType,
-  scalerFactoryFunc,
-} from '../../utils/proptypes';
+import GriffPropTypes, { seriesPropType } from '../../utils/proptypes';
 import XAxis from '../XAxis';
 import Layout from './Layout';
 import AxisPlacement from '../AxisPlacement';
@@ -31,7 +27,6 @@ const propTypes = {
   xAxisFormatter: PropTypes.func,
   xAxisPlacement: GriffPropTypes.axisPlacement,
   xAxisTicks: PropTypes.number,
-  xScalerFactory: scalerFactoryFunc.isRequired,
   // Number => String
   yAxisFormatter: PropTypes.func,
   yAxisPlacement: GriffPropTypes.axisPlacement,
@@ -91,7 +86,6 @@ const ScatterplotComponent = ({
   xAxisFormatter,
   xAxisPlacement,
   xAxisTicks,
-  xScalerFactory,
   yAxisFormatter,
   yAxisPlacement: propsYAxisPlacement,
   yAxisTicks,
@@ -165,7 +159,6 @@ const ScatterplotComponent = ({
             {...chartSize}
             onClick={onClick}
             zoomMode={ZoomMode.BOTH}
-            xScalerFactory={xScalerFactory}
             zoomAxes={{ x: zoomable, y: zoomable }}
           />
         </svg>
@@ -183,7 +176,6 @@ const ScatterplotComponent = ({
         <XAxis
           width={chartSize.width}
           height={X_AXIS_HEIGHT}
-          xScalerFactory={xScalerFactory}
           tickFormatter={xAxisFormatter}
           ticks={xAxisTicks}
           axis={Axes.x}
@@ -203,14 +195,13 @@ const SizedScatterplotComponent = sizeMe({
 })(ScatterplotComponent);
 
 const Scatterplot = props => (
-  <Scaler xScalerFactory={createLinearXScale}>
+  <Scaler>
     <ScalerContext.Consumer>
-      {({ collections, series, xScalerFactory }) => (
+      {({ collections, series }) => (
         <SizedScatterplotComponent
           {...props}
           collections={collections}
           series={series}
-          xScalerFactory={xScalerFactory}
         />
       )}
     </ScalerContext.Consumer>

--- a/src/components/XAxis/index.js
+++ b/src/components/XAxis/index.js
@@ -2,11 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 import { SizeMe } from 'react-sizeme';
-import GriffPropTypes, { scalerFactoryFunc } from '../../utils/proptypes';
+import GriffPropTypes from '../../utils/proptypes';
 import AxisPlacement from '../AxisPlacement';
 import ScalerContext from '../../context/Scaler';
 import ZoomRect from '../ZoomRect';
 import Axes from '../../utils/Axes';
+import { createXScale } from '../../utils/scale-helpers';
 
 const tickTransformer = v => `translate(${v}, 0)`;
 
@@ -23,7 +24,6 @@ const propTypes = {
 
   // These are provided by Griff.
   series: GriffPropTypes.multipleSeries.isRequired,
-  xScalerFactory: scalerFactoryFunc.isRequired,
   domainsByItemId: GriffPropTypes.domainsByItemId.isRequired,
   subDomainsByItemId: GriffPropTypes.subDomainsByItemId.isRequired,
 };
@@ -106,14 +106,13 @@ class XAxis extends Component {
       axis: a,
       width,
       stroke,
-      xScalerFactory,
       tickFormatter,
       ticks,
       domainsByItemId,
       subDomainsByItemId,
       scaled,
     } = this.props;
-    const scale = xScalerFactory(
+    const scale = createXScale(
       (scaled ? subDomainsByItemId : domainsByItemId)[
         Object.keys(domainsByItemId)[0]
       ][a],
@@ -196,12 +195,11 @@ XAxis.defaultProps = defaultProps;
 
 export default props => (
   <ScalerContext.Consumer>
-    {({ xScalerFactory, domainsByItemId, subDomainsByItemId, series }) => (
+    {({ domainsByItemId, subDomainsByItemId, series }) => (
       <SizeMe monitorWidth>
         {({ size }) => (
           <XAxis
             series={series}
-            xScalerFactory={xScalerFactory}
             {...props}
             width={size.width}
             domainsByItemId={domainsByItemId}

--- a/src/components/ZoomRect/index.js
+++ b/src/components/ZoomRect/index.js
@@ -385,17 +385,11 @@ ZoomRect.defaultProps = defaultProps;
 
 export default props => (
   <ScalerContext.Consumer>
-    {({
-      xScalerFactory,
-      domainsByItemId,
-      subDomainsByItemId,
-      updateDomains,
-    }) => (
+    {({ domainsByItemId, subDomainsByItemId, updateDomains }) => (
       <ZoomRect
         {...props}
         domainsByItemId={domainsByItemId}
         subDomainsByItemId={subDomainsByItemId}
-        xScalerFactory={xScalerFactory}
         updateDomains={updateDomains}
       />
     )}

--- a/src/utils/scale-helpers.js
+++ b/src/utils/scale-helpers.js
@@ -8,12 +8,6 @@ export const createYScale = (domain, height) =>
 
 export const createXScale = (domain, width) =>
   d3
-    .scaleTime()
-    .domain(domain)
-    .range([0, width]);
-
-export const createLinearXScale = (domain, width) =>
-  d3
     .scaleLinear()
     .domain(domain)
     .range([0, width]);

--- a/stories/XAxis.stories.js
+++ b/stories/XAxis.stories.js
@@ -4,8 +4,6 @@ import { storiesOf } from '@storybook/react';
 import moment from 'moment';
 import { DataProvider, XAxis, AxisPlacement } from '../src';
 import { staticLoader } from './loaders';
-import Scaler from '../src/components/Scaler';
-import { createXScale } from '../src/utils/scale-helpers';
 
 storiesOf('XAxis', module)
   .addDecorator(story => (
@@ -26,7 +24,7 @@ storiesOf('XAxis', module)
           <XAxis />
         </DataProvider>
       </div>
-      <div style={{ width: '75%' }}>
+      <div style={{ width: '50%' }}>
         <DataProvider
           defaultLoader={staticLoader}
           timeDomain={[+moment().subtract(1, 'week'), +moment()]}
@@ -34,9 +32,7 @@ storiesOf('XAxis', module)
           timeAccessor={d => +d.timestamp}
           yAccessor={d => +d.y}
         >
-          <Scaler xScalerFactory={createXScale}>
-            <XAxis />
-          </Scaler>
+          <XAxis />
         </DataProvider>
       </div>
     </React.Fragment>


### PR DESCRIPTION
With the introduction of XAxis' tickFormat functions, we no longer need
to have separate time-based and number-based scales. As a result, remove
the time-based ones and standardize on straight linear scales.