### PR TITLE
Show min/max areas if drawPoints is a function

### DIFF
--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -31,7 +31,7 @@ const Line = ({
       .curve(d3.curveStepAfter)
       .x(d => boundedSeries(xScale(xAxisAccessor(d))))
       .y(d => boundedSeries(yScale(yAccessor(d))));
-    if (drawPoints !== false && y0Accessor && y1Accessor) {
+    if (drawPoints !== true && y0Accessor && y1Accessor) {
       area = d3
         .area()
         .curve(d3.curveStepAfter)

--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -31,7 +31,11 @@ const Line = ({
       .curve(d3.curveStepAfter)
       .x(d => boundedSeries(xScale(xAxisAccessor(d))))
       .y(d => boundedSeries(yScale(yAccessor(d))));
-    if (!drawPoints && y0Accessor && y1Accessor) {
+    if (
+      (typeof drawPoints === 'function' || !drawPoints) &&
+      y0Accessor &&
+      y1Accessor
+    ) {
       area = d3
         .area()
         .curve(d3.curveStepAfter)
@@ -44,7 +48,11 @@ const Line = ({
       .line()
       .x(d => boundedSeries(xScale(xAxisAccessor(d))))
       .y(d => boundedSeries(yScale(yAccessor(d))));
-    if (!drawPoints && y0Accessor && y1Accessor) {
+    if (
+      (typeof drawPoints === 'function' || !drawPoints) &&
+      y0Accessor &&
+      y1Accessor
+    ) {
       area = d3
         .area()
         .x(d => boundedSeries(xScale(xAxisAccessor(d))))

--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -44,7 +44,7 @@ const Line = ({
       .line()
       .x(d => boundedSeries(xScale(xAxisAccessor(d))))
       .y(d => boundedSeries(yScale(yAccessor(d))));
-    if (drawPoints !== false && y0Accessor && y1Accessor) {
+    if (drawPoints !== true && y0Accessor && y1Accessor) {
       area = d3
         .area()
         .x(d => boundedSeries(xScale(xAxisAccessor(d))))

--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -31,11 +31,7 @@ const Line = ({
       .curve(d3.curveStepAfter)
       .x(d => boundedSeries(xScale(xAxisAccessor(d))))
       .y(d => boundedSeries(yScale(yAccessor(d))));
-    if (
-      (typeof drawPoints === 'function' || !drawPoints) &&
-      y0Accessor &&
-      y1Accessor
-    ) {
+    if (drawPoints !== false && y0Accessor && y1Accessor) {
       area = d3
         .area()
         .curve(d3.curveStepAfter)
@@ -48,11 +44,7 @@ const Line = ({
       .line()
       .x(d => boundedSeries(xScale(xAxisAccessor(d))))
       .y(d => boundedSeries(yScale(yAccessor(d))));
-    if (
-      (typeof drawPoints === 'function' || !drawPoints) &&
-      y0Accessor &&
-      y1Accessor
-    ) {
+    if (drawPoints !== false && y0Accessor && y1Accessor) {
       area = d3
         .area()
         .x(d => boundedSeries(xScale(xAxisAccessor(d))))


### PR DESCRIPTION
I'm a bit far from the current implementation but it seems if `drawPoints` is a function there is no need to hide min/max areas