### PR TITLE
make ruler work for live loading and sticky subdomain

### DIFF
--- a/src/components/InteractionLayer/index.js
+++ b/src/components/InteractionLayer/index.js
@@ -53,7 +53,6 @@ class InteractionLayer extends React.Component {
     series: seriesPropType,
     collections: GriffPropTypes.collections,
     timeSubDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
-    timeDomain: PropTypes.arrayOf(PropTypes.number).isRequired,
     subDomainsByItemId: GriffPropTypes.subDomainsByItemId.isRequired,
     // (domain, width) => [number, number]
     xScalerFactory: PropTypes.func.isRequired,
@@ -101,7 +100,6 @@ class InteractionLayer extends React.Component {
   componentWillReceiveProps(nextProps) {
     const {
       // FIXME: Migrate this to `subDomainsByItemId`.
-      timeSubDomain: prevTimeSubDomain,
       subDomainsByItemId: prevSubDomainsByItemId,
       ruler,
       xScalerFactory,
@@ -109,19 +107,24 @@ class InteractionLayer extends React.Component {
     } = this.props;
     // FIXME: Don't assume a single time domain
     const {
-      timeSubDomain: nextTimeSubDomain,
       width: nextWidth,
       subDomainsByItemId: nextSubDomainsByItemId,
     } = nextProps;
     const { touchX, touchY } = this.state;
+
+    const prevTimeSubDomain = Axes.time(
+      prevSubDomainsByItemId[Object.keys(prevSubDomainsByItemId)[0]]
+    );
+    const nextTimeSubDomain = Axes.time(
+      nextSubDomainsByItemId[Object.keys(nextSubDomainsByItemId)[0]]
+    );
 
     if (
       ruler &&
       ruler.visible &&
       touchX !== null &&
       (!isEqual(prevTimeSubDomain, nextTimeSubDomain) ||
-        prevWidth !== nextWidth ||
-        !isEqual(prevSubDomainsByItemId, nextSubDomainsByItemId))
+        prevWidth !== nextWidth)
     ) {
       // keep track on ruler on subdomain update
       const prevXScale = xScalerFactory(prevTimeSubDomain, prevWidth);
@@ -398,14 +401,16 @@ class InteractionLayer extends React.Component {
       subDomainsByItemId,
       xScalerFactory,
       // FIXME: Migrate this to `subDomainsByItemId`.
-      timeSubDomain,
     } = this.props;
     const newPoints = [];
     series.forEach(s => {
       if (!subDomainsByItemId[s.id]) {
         return;
       }
-      const { [Axes.y]: ySubDomain } = subDomainsByItemId[s.id];
+      const {
+        [Axes.time]: timeSubDomain,
+        [Axes.y]: ySubDomain,
+      } = subDomainsByItemId[s.id];
       const xScale = xScalerFactory(timeSubDomain, width);
       const rawTimestamp = xScale.invert(xpos).getTime();
       const { data, xAccessor, yAccessor } = s;
@@ -453,7 +458,10 @@ class InteractionLayer extends React.Component {
       });
       return;
     }
-    const { xScalerFactory, width, timeSubDomain } = this.props;
+    const { xScalerFactory, width, subDomainsByItemId } = this.props;
+    const timeSubDomain = Axes.time(
+      subDomainsByItemId[Object.keys(subDomainsByItemId)[0]]
+    );
     const xScale = xScalerFactory(timeSubDomain, width);
     const xpos = xScale(timestamp);
     this.setRulerPoints(xpos);
@@ -622,19 +630,9 @@ class InteractionLayer extends React.Component {
 
 export default props => (
   <ScalerContext.Consumer>
-    {({
-      timeSubDomain,
-      timeDomain,
-      collections,
-      series,
-      xScalerFactory,
-      subDomainsByItemId,
-    }) => (
+    {({ collections, series, xScalerFactory, subDomainsByItemId }) => (
       <InteractionLayer
         {...props}
-        // FIXME: Remove this crap
-        timeSubDomain={timeSubDomain}
-        timeDomain={timeDomain}
         collections={collections}
         series={series}
         xScalerFactory={xScalerFactory}

--- a/src/components/Scaler/index.js
+++ b/src/components/Scaler/index.js
@@ -168,23 +168,6 @@ class Scaler extends Component {
 
     if (
       !isEqual(
-        prevProps.dataContext.timeSubDomain,
-        this.props.dataContext.timeSubDomain
-      )
-    ) {
-      // When timeSubDomain changes, we need to update everything downstream.
-      const subDomainsByItemId = { ...this.state.subDomainsByItemId };
-      Object.keys(subDomainsByItemId).forEach(itemId => {
-        subDomainsByItemId[itemId][
-          Axes.time
-        ] = this.props.dataContext.timeSubDomain;
-      });
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ subDomainsByItemId });
-    }
-
-    if (
-      !isEqual(
         prevProps.dataContext.timeDomain,
         this.props.dataContext.timeDomain
       )
@@ -227,6 +210,24 @@ class Scaler extends Component {
 
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ domainsByItemId, subDomainsByItemId });
+
+      if (
+        !isEqual(
+          prevProps.dataContext.timeSubDomain,
+          this.props.dataContext.timeSubDomain
+        )
+      ) {
+        // When timeSubDomain changes, we need to update everything downstream.
+        const newSubDomainsByItemId = {};
+        Object.keys(this.state.subDomainsByItemId).forEach(itemId => {
+          newSubDomainsByItemId[itemId] = {
+            ...this.state.subDomainsByItemId[itemId],
+            [Axes.time]: this.props.dataContext.timeSubDomain,
+          };
+        });
+        // eslint-disable-next-line react/no-did-update-set-state
+        this.setState({ subDomainsByItemId: newSubDomainsByItemId });
+      }
     }
   }
 

--- a/stories/LineChart.stories.js
+++ b/stories/LineChart.stories.js
@@ -942,6 +942,31 @@ storiesOf('LineChart', module)
       <LineChart height={CHART_HEIGHT} />
     </DataProvider>
   ))
+  .add('Sticky x subdomain and ruler', () => (
+    <DataProvider
+      defaultLoader={liveLoader}
+      timeDomain={liveXDomain}
+      timeSubDomain={[Date.now() - 1000 * 20, Date.now() - 1000 * 10]}
+      updateInterval={33}
+      yAxisWidth={50}
+      series={[
+        { id: 1, color: 'steelblue', name: 'name1' },
+        { id: 2, color: 'maroon', name: 'name2' },
+      ]}
+      isTimeSubDomainSticky
+    >
+      <LineChart
+        height={CHART_HEIGHT}
+        ruler={{
+          visible: true,
+          yLabel: point =>
+            `${point.name}: ${Number.parseFloat(point.value).toFixed(3)}`,
+          timeLabel: point =>
+            moment(point.timestamp).format('DD-MM-YYYY HH:mm:ss'),
+        }}
+      />
+    </DataProvider>
+  ))
   .add('Limit x subdomain', () => {
     class LimitXSubDomain extends React.Component {
       limitXSubDomain = subDomain => {


### PR DESCRIPTION
the overarching problem here was that in `Scaler`'s `componentDidUpdate`, the `subDomainsByItemId` state was being directly mutated due to this shallow copy on line 176:
` const subDomainsByItemId = { ...this.state.subDomainsByItemId };`
This was causing weird behaviour for the ruler in `InteractionLayer`, since it was not picking up when `subDomainsByItemId` was changing. 

The fix to this was:
- not doing a shallow copy of `subDomainsByItemId`
- placing the check for a change in `timeSubDomain` after the check for a change in `timeDomain` in `Scaler`'s `componentDidUpdate` (the new value from `dataContext.timeSubDomain` should be prioritized over a the new value calculated from a new `dataContext.timeDomain`)
- since `subDomainsByItemId` is now being updated properly in `Scaler`, there is no need for `InteractionLayer` to have any knowledge of `dataContext.timeSubdomain`