### PR TITLE
Relicense under Apache 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2019 Cognite AS
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "author": "Cognite AS",
   "homepage": "https://griff.surge.sh/",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": "https://github.com/cognitedata/griff-react",
   "keywords": [
     "react-component"


### PR DESCRIPTION
Per Cognite's open-source policy, move griff-react to be released under
the Apache 2.0 license.