### PR TITLE
Add CSS class names to Ruler's components

### DIFF
--- a/src/components/Ruler/index.js
+++ b/src/components/Ruler/index.js
@@ -49,6 +49,7 @@ const Ruler = ({ ruler, points, height, width }) => {
   return (
     <React.Fragment>
       <line
+        className="ruler-line"
         y1={0}
         y2={height}
         stroke="#ccc"
@@ -76,6 +77,7 @@ const Ruler = ({ ruler, points, height, width }) => {
         />,
         <circle
           key={`circle${point.name || point.y}`}
+          className="ruler-circle"
           r={3}
           cx={point.x}
           cy={point.y}

--- a/src/components/RulerTooltip/index.js
+++ b/src/components/RulerTooltip/index.js
@@ -44,8 +44,10 @@ class RulerTooltip extends Component {
       <g
         transform={`translate(${xTranslate}, ${y})`}
         style={{ cursor: 'default' }}
+        className="ruler-tooltip"
       >
         <rect
+          className="ruler-tooltip-fill"
           fill="white"
           width={this.state.textWidth + padding}
           height={labelHeight}
@@ -57,6 +59,7 @@ class RulerTooltip extends Component {
           ry={3}
         />
         <text
+          className="ruler-tooltip-text"
           textAnchor="middle"
           alignmentBaseline="central"
           x={(this.state.textWidth + padding) / 2}


### PR DESCRIPTION
Allow the calling applications to override the look and feel of these
components by providing CSS class names for the DOM elements.