### PR TITLE
Export GridLines as a top-level component

### DIFF
--- a/src/components/GridLines/index.js
+++ b/src/components/GridLines/index.js
@@ -6,14 +6,19 @@ import { createYScale, createXScale } from '../../utils/scale-helpers';
 import Axes from '../../utils/Axes';
 
 const propTypes = {
-  grid: GriffPropTypes.grid,
-  height: PropTypes.number.isRequired,
-  width: PropTypes.number.isRequired,
-  series: seriesPropType.isRequired,
   axes: PropTypes.shape({
     x: PropTypes.oneOf(['x', 'time']),
   }),
+  color: GriffPropTypes.grid.color,
+  opacity: GriffPropTypes.grid.opacity,
+  strokeWidth: GriffPropTypes.grid.strokeWidth,
+  x: GriffPropTypes.grid.x,
+  y: GriffPropTypes.grid.y,
+
   // These are all populated by Griff.
+  height: PropTypes.number.isRequired,
+  width: PropTypes.number.isRequired,
+  series: seriesPropType.isRequired,
   subDomainsByItemId: GriffPropTypes.subDomainsByItemId.isRequired,
 };
 
@@ -27,18 +32,17 @@ const DEFAULT_OPACITY = 0.6;
 const DEFAULT_STROKE_WIDTH = 1;
 
 const GridLines = ({
-  grid,
-  height,
-  width,
-  series,
-  subDomainsByItemId,
   axes,
+  color,
+  height,
+  opacity,
+  series,
+  strokeWidth,
+  subDomainsByItemId,
+  width,
+  x,
+  y,
 }) => {
-  if (!grid) {
-    return null;
-  }
-
-  const { x, y } = grid;
   if (!x && !y) {
     return null;
   }
@@ -64,25 +68,17 @@ const GridLines = ({
               <line
                 key={`horizontal-${s.id}-${v}`}
                 className="grid-line grid-line-horizontal"
-                opacity={y.opacity || grid.opacity || DEFAULT_OPACITY}
+                opacity={y.opacity || opacity || DEFAULT_OPACITY}
                 stroke={
-                  y.color === null
-                    ? s.color
-                    : y.color || grid.color || DEFAULT_COLOR
+                  y.color === null ? s.color : y.color || color || DEFAULT_COLOR
                 }
                 strokeWidth={
-                  y.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH
+                  y.strokeWidth || strokeWidth || DEFAULT_STROKE_WIDTH
                 }
                 x1={0}
                 x2={width}
-                y1={
-                  (y.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH) /
-                  2
-                }
-                y2={
-                  (y.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH) /
-                  2
-                }
+                y1={(y.strokeWidth || strokeWidth || DEFAULT_STROKE_WIDTH) / 2}
+                y2={(y.strokeWidth || strokeWidth || DEFAULT_STROKE_WIDTH) / 2}
                 transform={`translate(0, ${scale(v)})`}
               />
             );
@@ -102,11 +98,9 @@ const GridLines = ({
             x2={width}
             y1={position}
             y2={position}
-            stroke={y.color || grid.color || DEFAULT_COLOR}
-            strokeWidth={
-              y.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH
-            }
-            opacity={y.opacity || grid.opacity || DEFAULT_OPACITY}
+            stroke={y.color || color || DEFAULT_COLOR}
+            strokeWidth={y.strokeWidth || strokeWidth || DEFAULT_STROKE_WIDTH}
+            opacity={y.opacity || opacity || DEFAULT_OPACITY}
           />
         );
       }
@@ -125,11 +119,9 @@ const GridLines = ({
             x2={width}
             y1={position}
             y2={position}
-            stroke={y.color || grid.color || DEFAULT_COLOR}
-            strokeWidth={
-              y.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH
-            }
-            opacity={y.opacity || grid.opacity || DEFAULT_OPACITY}
+            stroke={y.color || color || DEFAULT_COLOR}
+            strokeWidth={y.strokeWidth || strokeWidth || DEFAULT_STROKE_WIDTH}
+            opacity={y.opacity || opacity || DEFAULT_OPACITY}
           />
         );
       }
@@ -151,11 +143,9 @@ const GridLines = ({
             y2={height}
             x1={position}
             x2={position}
-            stroke={x.color || grid.color || DEFAULT_COLOR}
-            strokeWidth={
-              x.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH
-            }
-            opacity={x.opacity || grid.opacity || DEFAULT_OPACITY}
+            stroke={x.color || color || DEFAULT_COLOR}
+            strokeWidth={x.strokeWidth || strokeWidth || DEFAULT_STROKE_WIDTH}
+            opacity={x.opacity || opacity || DEFAULT_OPACITY}
           />
         );
       }
@@ -171,15 +161,13 @@ const GridLines = ({
           <line
             key={`vertical-${+v}`}
             className="grid-line grid-line-vertical"
-            opacity={x.opacity || grid.opacity || DEFAULT_OPACITY}
-            stroke={x.color || grid.color || DEFAULT_COLOR}
-            strokeWidth={
-              x.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH
-            }
+            opacity={x.opacity || opacity || DEFAULT_OPACITY}
+            stroke={x.color || color || DEFAULT_COLOR}
+            strokeWidth={x.strokeWidth || strokeWidth || DEFAULT_STROKE_WIDTH}
             y1={0}
             y2={height}
-            x1={(x.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH) / 2}
-            x2={(x.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH) / 2}
+            x1={(x.strokeWidth || strokeWidth || DEFAULT_STROKE_WIDTH) / 2}
+            x2={(x.strokeWidth || strokeWidth || DEFAULT_STROKE_WIDTH) / 2}
             transform={`translate(${scale(v)}, 0)`}
           />
         );
@@ -199,11 +187,9 @@ const GridLines = ({
             y2={height}
             x1={position}
             x2={position}
-            stroke={x.color || grid.color || DEFAULT_COLOR}
-            strokeWidth={
-              x.strokeWidth || grid.strokeWidth || DEFAULT_STROKE_WIDTH
-            }
-            opacity={x.opacity || grid.opacity || DEFAULT_OPACITY}
+            stroke={x.color || color || DEFAULT_COLOR}
+            strokeWidth={x.strokeWidth || strokeWidth || DEFAULT_STROKE_WIDTH}
+            opacity={x.opacity || opacity || DEFAULT_OPACITY}
           />
         );
       }

--- a/src/components/Scatterplot/index.js
+++ b/src/components/Scatterplot/index.js
@@ -9,14 +9,12 @@ import GriffPropTypes, { seriesPropType } from '../../utils/proptypes';
 import XAxis from '../XAxis';
 import Layout from './Layout';
 import AxisPlacement from '../AxisPlacement';
-import GridLines from '../GridLines';
 import Axes from '../../utils/Axes';
 import AxisCollection from '../AxisCollection';
 import LineCollection from '../LineCollection';
 import AxisDisplayMode from '../LineChart/AxisDisplayMode';
 
 const propTypes = {
-  grid: GriffPropTypes.grid,
   size: PropTypes.shape({
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
@@ -33,10 +31,12 @@ const propTypes = {
   yAxisTicks: PropTypes.number,
   collections: GriffPropTypes.collections.isRequired,
   series: seriesPropType.isRequired,
+
+  // The following props are all supplied internally (eg, by React).
+  children: PropTypes.arrayOf(PropTypes.node),
 };
 
 const defaultProps = {
-  grid: null,
   zoomable: true,
   onClick: null,
   xAxisFormatter: Number,
@@ -45,6 +45,8 @@ const defaultProps = {
   yAxisFormatter: Number,
   yAxisPlacement: AxisPlacement.RIGHT,
   yAxisTicks: null,
+
+  children: [],
 };
 
 const Y_AXIS_WIDTH = 50;
@@ -77,8 +79,8 @@ const getYAxisPlacement = ({ collections, series, yAxisPlacement }) => {
 };
 
 const ScatterplotComponent = ({
+  children,
   collections,
-  grid,
   series,
   size: { width, height },
   zoomable,
@@ -148,7 +150,19 @@ const ScatterplotComponent = ({
     <Layout
       chart={
         <svg style={{ width: '100%', height: '100%' }}>
-          <GridLines grid={grid} {...chartSize} />
+          {React.Children.map(children, child => {
+            const childProps = {
+              ...chartSize,
+              axes: {
+                ...(child.props || {}).axes,
+                [Axes.x]:
+                  ((child.props || {}).axes || {}).x === undefined
+                    ? String(Axes.x)
+                    : child.props.axes.x,
+              },
+            };
+            return React.cloneElement(child, childProps);
+          })}
           <PointCollection {...chartSize} />
           <LineCollection
             {...chartSize}

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
-export { default as DataProvider } from './components/DataProvider';
-export { default as ContextChart } from './components/ContextChart';
-export { default as LineChart } from './components/LineChart';
 export {
   default as AxisDisplayMode,
 } from './components/LineChart/AxisDisplayMode';
 export { default as AxisPlacement } from './components/AxisPlacement';
-export { default as Line } from './components/Line';
-export { default as XAxis } from './components/XAxis';
 export { default as Brush } from './components/Brush';
-export { default as Scatterplot } from './components/Scatterplot';
+export { default as ContextChart } from './components/ContextChart';
+export { default as DataProvider } from './components/DataProvider';
+export { default as GridLines } from './components/GridLines';
 export { default as GriffPropTypes } from './utils/proptypes';
+export { default as Line } from './components/Line';
+export { default as LineChart } from './components/LineChart';
+export { default as Scatterplot } from './components/Scatterplot';
+export { default as XAxis } from './components/XAxis';

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -149,7 +149,7 @@ const multipleSeries = PropTypes.arrayOf(singleSeries);
 /**
  * Specification for the grid rendered under the data.
  */
-const grid = PropTypes.shape({
+const grid = {
   /** Color of the lines (default: #000) */
   color: PropTypes.string,
   /** Thickness of the lines (default: 1) */
@@ -228,7 +228,7 @@ const grid = PropTypes.shape({
      */
     opacity: PropTypes.number,
   }),
-});
+};
 
 const updateDomains = PropTypes.func;
 

--- a/stories/GridLines.stories.js
+++ b/stories/GridLines.stories.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import 'react-select/dist/react-select.css';
 import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import { DataProvider, LineChart } from '../src';
 import { staticLoader } from './loaders';
+import GridLines from '../src/components/GridLines';
 
 const staticXDomain = [Date.now() - 1000 * 60 * 60 * 24 * 30, Date.now()];
 const CHART_HEIGHT = 500;
@@ -14,11 +16,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{ y: { pixels: 35 } }}
-        onZoomXAxis={t => console.log(t)}
-      />
+      <LineChart onZoomXAxis={action('onZoomXAxis')} height={CHART_HEIGHT}>
+        <GridLines y={{ pixels: 35 }} />
+      </LineChart>
     </DataProvider>
   ))
   .add('3 static horizontal lines', () => (
@@ -27,7 +27,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
-      <LineChart height={CHART_HEIGHT} grid={{ y: { count: 3 } }} />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines y={{ count: 3 }} />
+      </LineChart>
     </DataProvider>
   ))
   .add('Static vertical lines every 35 pixels', () => (
@@ -36,7 +38,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
-      <LineChart height={CHART_HEIGHT} grid={{ x: { pixels: 35 } }} />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines x={{ pixels: 35 }} />
+      </LineChart>
     </DataProvider>
   ))
   .add('3 static vertical lines', () => (
@@ -45,7 +49,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
-      <LineChart height={CHART_HEIGHT} grid={{ x: { count: 3 } }} />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines x={{ count: 3 }} />
+      </LineChart>
     </DataProvider>
   ))
   .add('Static grid lines every 75 pixels', () => (
@@ -54,10 +60,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{ x: { pixels: 75 }, y: { pixels: 75 } }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines x={{ pixels: 75 }} y={{ pixels: 75 }} />
+      </LineChart>
     </DataProvider>
   ))
   .add('3 grid lines', () => (
@@ -66,10 +71,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{ x: { count: 3 }, y: { count: 3 } }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines x={{ count: 3 }} y={{ count: 3 }} />
+      </LineChart>
     </DataProvider>
   ))
   .add('Dynamic horizontal lines', () => (
@@ -78,7 +82,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
-      <LineChart height={CHART_HEIGHT} grid={{ y: { seriesIds: [1] } }} />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines y={{ seriesIds: [1] }} />
+      </LineChart>
     </DataProvider>
   ))
   .add('Dynamic vertical lines', () => (
@@ -87,7 +93,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
-      <LineChart height={CHART_HEIGHT} grid={{ x: { ticks: 3 } }} />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines x={{ ticks: 3 }} />
+      </LineChart>
     </DataProvider>
   ))
   .add('Dynamic grid lines', () => (
@@ -96,10 +104,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{ x: { ticks: 0 }, y: { seriesIds: [1] } }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines x={{ ticks: 0 }} y={{ seriesIds: [1] }} />
+      </LineChart>
     </DataProvider>
   ))
   .add('Dynamic grid lines (multiple series)', () => (
@@ -108,10 +115,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{ x: { ticks: 0 }, y: { seriesIds: [1, 2], color: null } }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines x={{ ticks: 0 }} y={{ seriesIds: [1, 2], color: null }} />
+      </LineChart>
     </DataProvider>
   ))
   .add('color', () => [
@@ -121,10 +127,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{ y: { count: 5, color: 'red' } }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines y={{ count: 5, color: 'red' }} />
+      </LineChart>
     </DataProvider>,
     <DataProvider
       key="x-dimension"
@@ -132,10 +137,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{ x: { count: 5, color: 'red' } }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines x={{ count: 5, color: 'red' }} />
+      </LineChart>
     </DataProvider>,
     <DataProvider
       key="grid-object"
@@ -143,10 +147,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{ color: 'red', x: { count: 5 }, y: { count: 5 } }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines color="red" x={{ count: 5 }} y={{ count: 5 }} />
+      </LineChart>
     </DataProvider>,
     <DataProvider
       key="different"
@@ -154,14 +157,13 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{
-          color: 'yellow',
-          x: { count: 5, color: 'orange' },
-          y: { count: 5, color: 'green' },
-        }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines
+          color="yellow"
+          x={{ count: 5, color: 'orange' }}
+          y={{ count: 5, color: 'green' }}
+        />
+      </LineChart>
     </DataProvider>,
   ])
   .add('opacity', () => [
@@ -171,7 +173,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart height={CHART_HEIGHT} grid={{ y: { count: 5, opacity: 1 } }} />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines y={{ count: 5, opacity: 1 }} />
+      </LineChart>
     </DataProvider>,
     <DataProvider
       key="x-dimension"
@@ -179,7 +183,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart height={CHART_HEIGHT} grid={{ x: { count: 5, opacity: 1 } }} />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines x={{ count: 5, opacity: 1 }} />
+      </LineChart>
     </DataProvider>,
     <DataProvider
       key="grid-object"
@@ -187,10 +193,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{ opacity: 1, x: { count: 5 }, y: { count: 5 } }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines opacity={1} x={{ count: 5 }} y={{ count: 5 }} />
+      </LineChart>
     </DataProvider>,
     <DataProvider
       key="different"
@@ -198,14 +203,13 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{
-          opacity: 0,
-          x: { count: 5, opacity: 0.5 },
-          y: { count: 5, opacity: 1 },
-        }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines
+          opacity={0}
+          x={{ count: 5, opacity: 0.5 }}
+          y={{ count: 5, opacity: 1 }}
+        />
+      </LineChart>
     </DataProvider>,
   ])
   .add('strokeWidth', () => [
@@ -215,10 +219,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{ y: { count: 5, strokeWidth: 5 } }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines y={{ count: 5, strokeWidth: 5 }} />
+      </LineChart>
     </DataProvider>,
     <DataProvider
       key="x-dimension"
@@ -226,10 +229,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{ x: { count: 5, strokeWidth: 5 } }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines x={{ count: 5, strokeWidth: 5 }} />
+      </LineChart>
     </DataProvider>,
     <DataProvider
       key="grid-object"
@@ -237,10 +239,9 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{ strokeWidth: 5, x: { count: 5 }, y: { count: 5 } }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines strokeWidth={5} x={{ count: 5 }} y={{ count: 5 }} />
+      </LineChart>
     </DataProvider>,
     <DataProvider
       key="different"
@@ -248,13 +249,12 @@ storiesOf('Grid Lines', module)
       timeDomain={staticXDomain}
       series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
     >
-      <LineChart
-        height={CHART_HEIGHT}
-        grid={{
-          strokeWidth: 15,
-          x: { count: 5, strokeWidth: 5 },
-          y: { count: 5, strokeWidth: 10 },
-        }}
-      />
+      <LineChart height={CHART_HEIGHT}>
+        <GridLines
+          strokeWidth={15}
+          x={{ count: 5, strokeWidth: 5 }}
+          y={{ count: 5, strokeWidth: 10 }}
+        />
+      </LineChart>
     </DataProvider>,
   ]);

--- a/stories/Scatterplot.stories.js
+++ b/stories/Scatterplot.stories.js
@@ -3,7 +3,13 @@ import 'react-select/dist/react-select.css';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import moment from 'moment';
-import { DataProvider, Scatterplot, AxisPlacement, ContextChart } from '../src';
+import {
+  AxisPlacement,
+  ContextChart,
+  DataProvider,
+  GridLines,
+  Scatterplot,
+} from '../src';
 import { staticLoader, functionLoader } from './loaders';
 
 const mapping = {
@@ -394,12 +400,9 @@ storiesOf('Scatterplot', module)
         xAccessor={d => +d.x}
         yAccessor={d => +d.y}
       >
-        <Scatterplot
-          zoomable
-          grid={{ x: { ticks: 5 }, y: { count: 5, seriesIds: ['1 2'] } }}
-          xAxisTicks={5}
-          yAxisTicks={5}
-        />
+        <Scatterplot zoomable xAxisTicks={5} yAxisTicks={5}>
+          <GridLines x={{ ticks: 5 }} y={{ count: 5, seriesIds: ['1 2'] }} />
+        </Scatterplot>
       </DataProvider>
     </div>
   ))


### PR DESCRIPTION
Instead of controlling GridLines through props, allow it to be added
directly to the hierarchy as a child of the desired chart (eg, LineChart
or Scatterplot). This allows for a flatter prop structure as well as
beginning the migration of business logic from inside of Griff back into
the client application.