### PR TITLE
Add error handler callback to DataProvider

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -745,7 +745,8 @@ DataProvider.propTypes = {
   // loaderConfig => void
   // called whenever data is fetched by the loader
   onFetchData: PropTypes.func,
-  // Callback when fetching data from backend returns an error
+  // error => void
+  // Callback when data loader throws an error
   onFetchDataError: PropTypes.func,
 };
 


### PR DESCRIPTION
So that other components using this can have custom error handling functionality in case the data fails to come back.

Relates to https://github.com/cognitedata/operational-intelligence/issues/1993