### PR TITLE
Ensure tickFormatter gets a number (or NaN)

### DIFF
--- a/src/components/AxisCollection/YAxis.js
+++ b/src/components/AxisCollection/YAxis.js
@@ -18,7 +18,7 @@ const propTypes = {
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
   yAxisPlacement: GriffPropTypes.axisPlacement,
-  // Number => String
+  // (number, values) => String
   tickFormatter: PropTypes.func.isRequired,
   defaultColor: PropTypes.string,
   ticks: PropTypes.number,
@@ -220,7 +220,7 @@ const YAxis = ({
           <g key={+v} opacity={1} transform={`translate(0, ${scale(v)})`}>
             <line {...lineProps} />
             <text className="tick-value" {...textProps}>
-              {tickFormatter(v, values)}
+              {tickFormatter(+v, values)}
             </text>
           </g>
         );

--- a/src/components/XAxis/index.js
+++ b/src/components/XAxis/index.js
@@ -34,7 +34,7 @@ const propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
   stroke: PropTypes.string,
-  // Number => String
+  // (number, values) => String
   tickFormatter: PropTypes.func,
   ticks: PropTypes.number,
   placement: GriffPropTypes.axisPlacement,


### PR DESCRIPTION
tickFormatter should always get a number (or NaN if we're somehow trying
to plot a non-number object).