### PR TITLE
Allow specifying custom # of y-axis ticks when using LineChart

### DIFF
--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -45,6 +45,7 @@ const propTypes = {
   xSubDomain: PropTypes.arrayOf(PropTypes.number),
   xAxisHeight: PropTypes.number,
   contextChart: GriffPropTypes.contextChart,
+  yAxisTicks: PropTypes.number,
   ruler: rulerPropType,
   annotations: PropTypes.arrayOf(annotationPropType),
   // Number => String
@@ -110,6 +111,7 @@ const defaultProps = {
   xAxisHeight: 50,
   // eslint-disable-next-line react/default-props-match-prop-types
   yAxisWidth: 50,
+  yAxisTicks: null,
   width: 0,
   height: 0,
   xSubDomain: [],
@@ -249,6 +251,7 @@ const LineChart = props => {
     yAxisDisplayMode,
     yAxisFormatter,
     yAxisWidth,
+    yAxisTicks,
     zoomable,
   } = props;
 
@@ -328,6 +331,7 @@ const LineChart = props => {
           height={chartSize.height}
           tickFormatter={yAxisFormatter}
           yAxisWidth={yAxisWidth}
+          ticks={yAxisTicks}
         />
       }
       xAxis={

--- a/stories/LineChart.stories.js
+++ b/stories/LineChart.stories.js
@@ -60,6 +60,15 @@ storiesOf('LineChart', module)
       />
     </DataProvider>
   ))
+  .add('Custom # of y-axis ticks', () => (
+    <DataProvider
+      defaultLoader={staticLoader}
+      timeDomain={staticXDomain}
+      series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+    >
+      <LineChart height={CHART_HEIGHT} yAxisTicks={15} />
+    </DataProvider>
+  ))
   .add('Multiple', () => (
     <React.Fragment>
       <DataProvider


### PR DESCRIPTION
Be like the Scatterplot

Relates to https://github.com/cognitedata/operational-intelligence/issues/2119