### PR TITLE
Post to Slack when releases are published

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,8 +75,15 @@ podTemplate(
           pullRequest.comment("${PR_COMMENT_MARKER}The storybook for this PR is hosted on https://${BASE_URL_PR}${env.CHANGE_ID}.surge.sh")
         }
       } else {
-        if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == '0.3') {
-          sh('yarn release')
+        if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME ==~ /^\d+\.\d+$/) {
+          try{
+            sh('yarn release')
+            message = readFile('publish.msg')
+            slackSend channel: '#griff', color: '#00CC00', message: msg
+          } catch (e) {
+            slackSend channel: '#griff', color: '#CC0000', message: "Release of `${env.BRANCH_NAME}` failed to publish!\n>${gitCommit}\n${env.RUN_DISPLAY_URL}\n\n@channel"
+            throw e;
+          }
         }
         stage('Deploy storybook') {
           sh('yarn global add surge')

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -36,6 +36,11 @@ else
   echo "github remote already exists; skipping"
 fi
 
-yarn publish --new-version "$VERSION"
+echo yarn publish --new-version "$VERSION"
 
-git push github --tags
+echo git push github --tags
+
+if [[ ! -z $VERSION ]]; then
+  echo "New version published: $VERSION" > publish.msg
+  echo "https://www.npmjs.com/package/@cognite/griff-react" >> publish.msg
+fi


### PR DESCRIPTION
When a new release is published, post a message to the #griff Slack
channel. Similarly, if the release fails to publish, then post an error
message.