### PR TITLE
Updated annotations to be used across yAxis

### DIFF
--- a/src/components/Annotation/index.js
+++ b/src/components/Annotation/index.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { annotationShape } from '../../utils/proptypes';
-import { boundedSeries } from '../utils/boundedseries';
+import { boundedSeries } from '../../utils/boundedseries';
 
 const Annotation = ({
   timeBounds,
   seriesBounds,
+  data,
   xScale,
   yScale,
   height,
@@ -15,6 +16,13 @@ const Annotation = ({
 }) => {
   const xBounds = { min: 0, max: 0 };
   const yBounds = { min: 0, max: 0 };
+
+  if (data) {
+    xBounds.min = data[0] ? xScale(data[0] || Number.MIN_SAFE_INTEGER) : 0;
+    xBounds.max = data[1]
+      ? xScale(data[1] || Number.MAX_SAFE_INTEGER)
+      : Number.MAX_SAFE_INTEGER;
+  }
 
   if (timeBounds) {
     xBounds.min = timeBounds.min
@@ -49,7 +57,9 @@ const Annotation = ({
           : height
       }
       width={
-        timeBounds ? Math.abs(boundedSeries(xBounds.max - xBounds.min)) : width
+        timeBounds || data
+          ? Math.abs(boundedSeries(xBounds.max - xBounds.min))
+          : width
       }
       style={{ stroke: color, fill: color, fillOpacity }}
     />

--- a/src/components/Annotation/index.js
+++ b/src/components/Annotation/index.js
@@ -1,17 +1,65 @@
 import React from 'react';
 import { annotationShape } from '../../utils/proptypes';
 
-const Annotation = ({ data, xScale, height, color, fillOpacity, id }) => (
-  <rect
-    key={id}
-    className={`griff-annotation griff-annotation-${id}`}
-    x={xScale(data[0])}
-    y={0}
-    height={height}
-    width={xScale(data[1]) - xScale(data[0])}
-    style={{ stroke: color, fill: color, fillOpacity }}
-  />
-);
+// HTML has an issue with drawing points somewhere in the 30-35M range.
+// There's no point in drawing pixels more than 30k pixels outside of the range
+// so this hack will work for a while.
+// Without this, when zoomed far enough in the line will disappear.
+const boundedValue = value => Math.min(Math.max(value, -30000), 30000);
+
+const Annotation = ({
+  timeBounds,
+  seriesBounds,
+  xScale,
+  yScale,
+  height,
+  width,
+  color,
+  fillOpacity,
+  id,
+}) => {
+  const xBounds = { min: 0, max: 0 };
+  const yBounds = { min: 0, max: 0 };
+
+  if (timeBounds) {
+    xBounds.min = timeBounds.min
+      ? xScale(timeBounds.min || Number.MIN_SAFE_INTEGER)
+      : 0;
+    xBounds.max = timeBounds.max
+      ? xScale(timeBounds.max || Number.MAX_SAFE_INTEGER)
+      : Number.MAX_SAFE_INTEGER;
+  }
+
+  if (seriesBounds) {
+    yBounds.min =
+      yScale && seriesBounds.min
+        ? yScale(seriesBounds.min || Number.MIN_SAFE_INTEGER)
+        : 0;
+
+    yBounds.max =
+      yScale && seriesBounds.max
+        ? yScale(seriesBounds.max || Number.MAX_SAFE_INTEGER)
+        : Number.MAX_SAFE_INTEGER;
+  }
+
+  return (
+    <rect
+      key={id}
+      className={`griff-annotation griff-annotation-${id}`}
+      x={boundedValue(xBounds.min)}
+      y={boundedValue(yBounds.min)}
+      height={
+        seriesBounds
+          ? Math.abs(boundedValue(yBounds.max - yBounds.min))
+          : height
+      }
+      width={
+        timeBounds ? Math.abs(boundedValue(xBounds.max - xBounds.min)) : width
+      }
+      style={{ stroke: color, fill: color, fillOpacity }}
+    />
+  );
+};
 
 Annotation.propTypes = annotationShape;
 

--- a/src/components/Annotation/index.js
+++ b/src/components/Annotation/index.js
@@ -1,11 +1,6 @@
 import React from 'react';
 import { annotationShape } from '../../utils/proptypes';
-
-// HTML has an issue with drawing points somewhere in the 30-35M range.
-// There's no point in drawing pixels more than 30k pixels outside of the range
-// so this hack will work for a while.
-// Without this, when zoomed far enough in the line will disappear.
-const boundedValue = value => Math.min(Math.max(value, -30000), 30000);
+import { boundedSeries } from '../utils/boundedseries';
 
 const Annotation = ({
   timeBounds,
@@ -46,15 +41,15 @@ const Annotation = ({
     <rect
       key={id}
       className={`griff-annotation griff-annotation-${id}`}
-      x={boundedValue(xBounds.min)}
-      y={boundedValue(yBounds.min)}
+      x={boundedSeries(xBounds.min)}
+      y={boundedSeries(yBounds.min)}
       height={
         seriesBounds
-          ? Math.abs(boundedValue(yBounds.max - yBounds.min))
+          ? Math.abs(boundedSeries(yBounds.max - yBounds.min))
           : height
       }
       width={
-        timeBounds ? Math.abs(boundedValue(xBounds.max - xBounds.min)) : width
+        timeBounds ? Math.abs(boundedSeries(xBounds.max - xBounds.min)) : width
       }
       style={{ stroke: color, fill: color, fillOpacity }}
     />

--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -106,9 +106,26 @@ const ContextChart = ({
   });
   const xScale = createXScale(timeDomain, width);
   const selection = timeSubDomain.map(xScale);
-  const annotations = propsAnnotations.map(a => (
-    <Annotation key={a.id} {...a} height={height} xScale={xScale} />
-  ));
+
+  const annotations = propsAnnotations.map(a => {
+    let yScale = null;
+
+    if (a.seriesBounds) {
+      const serie = series.find(s1 => s1.id === a.seriesBounds.id);
+      yScale = createYScale(serie.ySubDomain, height);
+    }
+
+    return (
+      <Annotation
+        key={a.id}
+        height={height}
+        width={width}
+        xScale={xScale}
+        yScale={yScale}
+        {...a}
+      />
+    );
+  });
 
   const xAxis = (
     <XAxis

--- a/src/components/InteractionLayer/index.js
+++ b/src/components/InteractionLayer/index.js
@@ -537,9 +537,28 @@ class InteractionLayer extends React.Component {
     // FIXME: Don't rely on a single time domain
     const timeSubDomain = Axes.time(subDomainsByItemId[series[0].id]);
     const xScale = createXScale(timeSubDomain, width);
-    const annotations = propsAnnotations.map(a => (
-      <Annotation key={a.id} {...a} height={height} xScale={xScale} />
-    ));
+
+    const annotations = propsAnnotations.map(a => {
+      let yScale = null;
+
+      if (a.seriesBounds) {
+        const serie = series.find(s1 => s1.id === a.seriesBounds.id);
+        const ySubDomain = Axes.y(subDomainsByItemId[serie.id]);
+        yScale = createYScale(ySubDomain, height);
+      }
+
+      return (
+        <Annotation
+          key={a.id}
+          height={height}
+          width={width}
+          xScale={xScale}
+          yScale={yScale}
+          {...a}
+        />
+      );
+    });
+
     const areas = propsAreas.map(a => {
       const scaledArea = {
         ...a,

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -52,6 +52,15 @@ export const domainPropType = PropTypes.arrayOf(PropTypes.number.isRequired);
 
 export const annotationShape = {
   data: PropTypes.arrayOf(PropTypes.number),
+  timeBounds: PropTypes.shape({
+    min: PropTypes.number,
+    max: PropTypes.number,
+  }),
+  seriesBounds: PropTypes.shape({
+    id: idPropType.isRequired,
+    min: PropTypes.number,
+    max: PropTypes.number,
+  }),
   xScale: PropTypes.func,
   height: PropTypes.number,
   id: PropTypes.number,

--- a/stories/LineChart.stories.js
+++ b/stories/LineChart.stories.js
@@ -483,8 +483,77 @@ storiesOf('LineChart', module)
     const exampleAnnotations = [
       {
         id: 1,
-        data: [series[40].timestamp, series[60].timestamp],
+        timeBounds: { min: series[40].timestamp, max: series[60].timestamp },
         color: 'black',
+      },
+      {
+        id: 2,
+        seriesBounds: {
+          id: 1,
+          min: 0.2,
+          max: 0.4,
+        },
+        color: 'red',
+      },
+      {
+        id: 3,
+        seriesBounds: {
+          id: 2,
+          min: 0.6,
+          max: 0.9,
+        },
+        timeBounds: { min: series[120].timestamp, max: series[160].timestamp },
+        color: 'green',
+      },
+    ];
+    return (
+      <DataProvider
+        defaultLoader={staticLoader}
+        timeDomain={staticXDomain}
+        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+      >
+        <LineChart height={CHART_HEIGHT} annotations={exampleAnnotations} />
+      </DataProvider>
+    );
+  })
+  .add('Annotations with infinite bounds', () => {
+    const series = staticLoader({
+      id: 1,
+      reason: 'MOUNTED',
+      timeDomain: staticXDomain,
+    }).data;
+    const exampleAnnotations = [
+      {
+        id: 1,
+        timeBounds: { min: series[60].timestamp },
+        color: 'black',
+      },
+      {
+        id: 2,
+        timeBounds: { max: series[40].timestamp },
+        color: 'black',
+      },
+      {
+        id: 3,
+        seriesBounds: { id: 1, min: 0.8 },
+        color: 'red',
+      },
+      {
+        id: 4,
+        seriesBounds: { id: 1, max: 0.2 },
+        color: 'red',
+      },
+      {
+        id: 5,
+        timeBounds: { min: series[120].timestamp },
+        seriesBounds: { id: 2, min: 0.3 },
+        color: 'green',
+      },
+      {
+        id: 6,
+        timeBounds: { max: series[140].timestamp },
+        seriesBounds: { id: 2, max: 0.2 },
+        color: 'blue',
       },
     ];
     return (

--- a/stories/LineChart.stories.js
+++ b/stories/LineChart.stories.js
@@ -474,6 +474,30 @@ storiesOf('LineChart', module)
     }
     return <SpecifyDomain />;
   })
+
+  .add('Annotations (old props)', () => {
+    const series = staticLoader({
+      id: 1,
+      reason: 'MOUNTED',
+      timeDomain: staticXDomain,
+    }).data;
+    const exampleAnnotations = [
+      {
+        id: 1,
+        data: [series[10].timestamp, series[20].timestamp],
+        color: 'orange',
+      },
+    ];
+    return (
+      <DataProvider
+        defaultLoader={staticLoader}
+        timeDomain={staticXDomain}
+        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+      >
+        <LineChart height={CHART_HEIGHT} annotations={exampleAnnotations} />
+      </DataProvider>
+    );
+  })
   .add('Annotations', () => {
     const series = staticLoader({
       id: 1,


### PR DESCRIPTION
This PR upgrades annotations to support being placed on a series instead of just on the X axis. 

Todo before merge:
- [x] Make it backwards compatible (or at least give a warning and an upgrade path)
- [x] Discuss API with @evancharlton 
- [x] Possibly replace areas with annotations instead