### PR TITLE
Prevent a chart from growing continuously in height

### DIFF
--- a/src/components/LineChart/Layout.js
+++ b/src/components/LineChart/Layout.js
@@ -169,7 +169,12 @@ const Layout = ({
     >
       <div
         className="lines-container"
-        style={{ gridArea: 'chart', height: '100%' }}
+        style={{
+          gridArea: 'chart',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+        }}
       >
         {lineChart}
       </div>


### PR DESCRIPTION
When a container is set to 100% height, but the container fails to grow because it has no parent to set its height from, the chart would grow infinitely. This _should_ stop that