### PR TITLE
Ported Points and PointCollection to TypeScript

### DIFF
--- a/src/components/PointCollection/index.tsx
+++ b/src/components/PointCollection/index.tsx
@@ -1,10 +1,20 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
 import ScalerContext from '../../context/Scaler';
 import { createYScale, createXScale } from '../../utils/scale-helpers';
-import Points from '../Points';
 import GriffPropTypes, { seriesPropType } from '../../utils/proptypes';
 import Axes from '../../utils/Axes';
+import { SizeProps } from '../../internal';
+import { Series, Datapoint } from '../../external';
+import { DomainsByItemId } from '../Scaler';
+import Points from '../Points';
+
+export interface Props {}
+
+interface InternalProps {
+  series: Series[];
+  subDomainsByItemId: DomainsByItemId;
+}
 
 const propTypes = {
   width: PropTypes.number.isRequired,
@@ -14,7 +24,9 @@ const propTypes = {
 };
 const defaultProps = {};
 
-const PointCollection = ({ width, height, series, subDomainsByItemId }) => {
+const PointCollection: React.FunctionComponent<
+  Props & SizeProps & InternalProps
+> = ({ width, height, series, subDomainsByItemId }) => {
   const points = series
     .filter(s => !s.hidden && s.drawPoints !== false)
     .map(s => {
@@ -32,8 +44,8 @@ const PointCollection = ({ width, height, series, subDomainsByItemId }) => {
       // infinity so that they go to the ends of the graph, but points are special
       // since they can overlap in the [x,y] plane, but not be in the current time
       // subdomain.
-      const pointFilter = d => {
-        const timestamp = s.timeAccessor(d);
+      const pointFilter = (d: Datapoint, i: number, arr: Datapoint[]) => {
+        const timestamp = s.timeAccessor(d, i, arr);
         const subDomain = Axes.time(subDomainsByItemId[s.id]);
         return subDomain[0] <= timestamp && timestamp <= subDomain[1];
       };
@@ -61,9 +73,9 @@ const PointCollection = ({ width, height, series, subDomainsByItemId }) => {
 PointCollection.propTypes = propTypes;
 PointCollection.defaultProps = defaultProps;
 
-export default props => (
+export default (props: Props & SizeProps) => (
   <ScalerContext.Consumer>
-    {({ subDomainsByItemId, series }) => (
+    {({ subDomainsByItemId, series }: InternalProps) => (
       <PointCollection
         {...props}
         series={series}

--- a/src/components/Points/index.tsx
+++ b/src/components/Points/index.tsx
@@ -1,51 +1,33 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import GriffPropTypes, {
-  dataPointPropType,
-  accessorFuncPropType,
-  scaleFuncPropType,
-} from '../../utils/proptypes';
+import * as React from 'react';
 import { boundedSeries } from '../../utils/boundedseries';
+import { Datapoint, PointRenderer, AccessorFunction } from '../../external';
+import { ScalerFunction } from '../../utils/scale-helpers';
 
-const propTypes = {
-  data: PropTypes.arrayOf(dataPointPropType).isRequired,
-  drawPoints: GriffPropTypes.drawPoints,
-  xAccessor: accessorFuncPropType.isRequired,
-  x0Accessor: accessorFuncPropType,
-  x1Accessor: accessorFuncPropType,
-  yAccessor: accessorFuncPropType.isRequired,
-  y0Accessor: accessorFuncPropType,
-  y1Accessor: accessorFuncPropType,
-  xScale: scaleFuncPropType.isRequired,
-  yScale: scaleFuncPropType.isRequired,
-  color: PropTypes.string.isRequired,
-  opacity: PropTypes.number,
-  opacityAccessor: PropTypes.func,
-  pointFilter: PropTypes.func,
-  pointWidth: PropTypes.number,
-  pointWidthAccessor: PropTypes.func,
-  strokeWidth: PropTypes.number,
-};
-
-const defaultProps = {
-  drawPoints: false,
-  opacity: 1,
-  opacityAccessor: null,
-  pointFilter: () => true,
-  pointWidth: null,
-  pointWidthAccessor: null,
-  strokeWidth: null,
-  x0Accessor: null,
-  x1Accessor: null,
-  y0Accessor: null,
-  y1Accessor: null,
-};
+export interface Props {
+  drawPoints?: boolean | PointRenderer;
+  color?: string;
+  opacity?: number;
+  opacityAccessor?: AccessorFunction;
+  pointFilter?: (d: Datapoint, i: number, arr: Datapoint[]) => boolean;
+  pointWidth?: number;
+  pointWidthAccessor?: AccessorFunction;
+  strokeWidth?: number;
+  data: Datapoint[];
+  xAccessor: AccessorFunction;
+  x0Accessor: AccessorFunction;
+  x1Accessor: AccessorFunction;
+  yAccessor: AccessorFunction;
+  y0Accessor: AccessorFunction;
+  y1Accessor: AccessorFunction;
+  xScale: ScalerFunction;
+  yScale: ScalerFunction;
+}
 
 const defaultMinMaxAccessor = () => undefined;
 
-const Points = ({
+const Points: React.FunctionComponent<Props> = ({
   data,
-  drawPoints,
+  drawPoints = false,
   xAccessor,
   x0Accessor,
   x1Accessor,
@@ -55,9 +37,9 @@ const Points = ({
   xScale,
   yScale,
   color,
-  opacity,
+  opacity = 1,
   opacityAccessor,
-  pointFilter,
+  pointFilter = () => true,
   pointWidth,
   pointWidthAccessor,
   strokeWidth,
@@ -71,13 +53,13 @@ const Points = ({
       xAccessor,
       x0Accessor || defaultMinMaxAccessor,
       x1Accessor || defaultMinMaxAccessor,
-    ].map(f => +boundedSeries(xScale(f(d))));
+    ].map(func => +boundedSeries(xScale(func(d, i, arr))));
 
     const [y, y0, y1] = [
       yAccessor,
       y0Accessor || defaultMinMaxAccessor,
       y1Accessor || defaultMinMaxAccessor,
-    ].map(f => +boundedSeries(yScale(f(d))));
+    ].map(func => +boundedSeries(yScale(func(d, i, arr))));
 
     let width = 0;
     if (pointWidthAccessor) {
@@ -154,8 +136,5 @@ const Points = ({
   });
   return <g>{points}</g>;
 };
-
-Points.propTypes = propTypes;
-Points.defaultProps = defaultProps;
 
 export default Points;

--- a/src/external.d.ts
+++ b/src/external.d.ts
@@ -5,6 +5,43 @@ export type Domain = [number, number];
 
 export type ItemId = string | number;
 
-export interface Series extends Item {}
+export interface Series extends Item {
+  collectionId?: ItemId;
+}
 
 export interface Collection extends Item {}
+
+export interface Datapoint {
+  timestamp?: number;
+  x?: number;
+  y?: number;
+}
+
+export type AccessorFunction = (
+  d: Datapoint,
+  i: number,
+  arr: Datapoint[]
+) => number;
+
+export interface PointRendererMetadata {
+  x: number;
+  x0?: number;
+  x1?: number;
+  y: number;
+  y0?: number;
+  y1?: number;
+  color?: string;
+  opacity?: number;
+  opacityAccessor?: AccessorFunction;
+  pointWidth?: number;
+  pointWidthAccessor?: AccessorFunction;
+  strokeWidth?: number;
+}
+
+export type PointRenderer = (
+  d: Datapoint,
+  i: number,
+  data: Datapoint[],
+  metadata: PointRendererMetadata,
+  uiElements: React.ReactElement[]
+) => React.ReactElement[] | null;

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -1,8 +1,18 @@
-import { ItemId, Domain } from './external';
+import { ItemId, Domain, AccessorFunction } from './external';
 
 export interface Item {
   id: ItemId;
+  data: Datapoint[];
   color?: string;
+  hidden?: boolean;
+  drawPoints?: boolean;
+  timeAccessor: AccessorFunction;
+  xAccessor: AccessorFunction;
+  x0Accessor: AccessorFunction;
+  x1Accessor: AccessorFunction;
+  yAccessor: AccessorFunction;
+  y0Accessor: AccessorFunction;
+  y1Accessor: AccessorFunction;
   timeDomain?: Domain;
   timeSubDomain?: Domain;
   xDomain?: Domain;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,8 @@
     "jsx": "react",
     "allowJs": true,
     "module": "es2015",
-    "lib": [
-      "es2015",
-      "dom"
-    ]
+    "lib": ["es2015", "dom"],
+    "moduleResolution": "node"
   },
   "include": [
     "src/*.js",


### PR DESCRIPTION
These two come as a pair, so it makes sense to port them at the same
time.

Also move tsc to use `moduleResolution: node` to handle the default
imports/exports.