### PR TITLE
Build with ES5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "d3": "4.10.0",
     "immutable": "^3.8.2",
     "lodash.isequal": "^4.5.0",
+    "prop-types": "^15.7.2",
     "react-sizeme": "^2.5.2"
   },
   "peerDependencies": {
@@ -64,7 +65,6 @@
     "moment": "^2.19.3",
     "nodemon": "^1.17.4",
     "plotly.js": "^1.44.4",
-    "prop-types": "^15.7.2",
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
     "react-plotly.js": "^2.2.0",

--- a/src/utils/proptypes.js
+++ b/src/utils/proptypes.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { AxisDisplayMode } from '..';
+import AxisDisplayMode from '../components/LineChart/AxisDisplayMode';
 import AxisPlacement from '../components/AxisPlacement';
 import Axes from './Axes';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "jsx": "react",
     "allowJs": true,
+    "target": "es5",
     "module": "es2015",
     "lib": ["es2015", "dom"],
     "moduleResolution": "node"


### PR DESCRIPTION
Publish the module as ES5 so that legacy systems can still use the
project.

Also resolve some dependency issues.