### PR TITLE
Make TypeScript happier with Scaler

### DIFF
--- a/src/components/Scaler/index.tsx
+++ b/src/components/Scaler/index.tsx
@@ -44,6 +44,8 @@ interface State {
 
 export interface OnDomainsUpdated extends Function {}
 
+type DomainAxis = 'time' | 'x' | 'y';
+
 // If the timeSubDomain is within this margin, consider it to be attached to
 // the leading edge of the timeDomain.
 const FRONT_OF_WINDOW_THRESHOLD = 0.05;
@@ -315,8 +317,8 @@ class Scaler extends React.Component<Props, State> {
     const newSubDomains = { ...subDomainsByItemId };
     Object.keys(changedDomainsById).forEach(itemId => {
       newSubDomains[itemId] = { ...(subDomainsByItemId[itemId] || {}) };
-      Object.keys(changedDomainsById[itemId]).forEach(axis => {
-        // @ts-ignore - We know that "axis" here is a Dimension string.
+      Object.keys(changedDomainsById[itemId]).forEach(uncastAxis => {
+        const axis: DomainAxis = uncastAxis as DomainAxis;
         let newSubDomain = changedDomainsById[itemId][axis];
         if (axis === String(Axes.time)) {
           if (dataContext.limitTimeSubDomain) {
@@ -327,12 +329,10 @@ class Scaler extends React.Component<Props, State> {
         const newSpan = newSubDomain[1] - newSubDomain[0];
 
         const existingSubDomain =
-          // @ts-ignore - We know that "axis" here is a Dimension string.
           subDomainsByItemId[itemId][axis] || newSubDomain;
         const existingSpan = existingSubDomain[1] - existingSubDomain[0];
 
         const limits = stripPlaceholderDomain(
-          // @ts-ignore - We know that "axis" here is a Dimension string.
           ((domainsByItemId || {})[itemId] || {})[axis] ||
             (axis === String(Axes.time)
               ? // FIXME: Phase out this single timeDomain thing.
@@ -355,7 +355,6 @@ class Scaler extends React.Component<Props, State> {
           ];
         }
 
-        // @ts-ignore - We know that "axis" here is a Dimension string.
         newSubDomains[itemId][axis] = newSubDomain;
 
         if (axis === String(Axes.time)) {


### PR DESCRIPTION
Remove the @ts-ignore declarations in Scaler/index.tsx by making the
known-to-be-safe assumptions explicit through casting.