### PR TITLE
Explicitly cast domain.map to Domain

### DIFF
--- a/src/components/Brush/index.tsx
+++ b/src/components/Brush/index.tsx
@@ -158,8 +158,7 @@ class Brush extends React.Component<Props, State> {
       const { dragStartSelection } = this.state;
       const position = e.nativeEvent.offsetX;
       const dx = position - (dragStartSelection || 0);
-      // @ts-ignore - We know this is a Domain.
-      const newSelection: Domain = selection.map(d => d + dx);
+      const newSelection: Domain = selection.map(d => d + dx) as Domain;
       if (newSelection[0] >= 0 && newSelection[1] <= width) {
         this.setState({
           dragStartSelection: position,
@@ -168,11 +167,10 @@ class Brush extends React.Component<Props, State> {
       }
     } else if (isDraggingOverlay) {
       const { dragStartOverlay } = this.state;
-      // @ts-ignore - We know this is a Domain.
       const newSelection: Domain = [
         dragStartOverlay || 0,
         e.nativeEvent.offsetX,
-      ].sort((a, b) => a - b);
+      ].sort((a, b) => a - b) as Domain;
       onUpdateSelection(newSelection);
     }
   };

--- a/src/components/XAxis/index.tsx
+++ b/src/components/XAxis/index.tsx
@@ -182,8 +182,7 @@ const XAxis: React.FunctionComponent<Props & ScalerProps & SizeProps> = ({
   // regular 1280 display. So by dividing width by ~100
   // we can achieve appropriate amount of ticks for any width.
   const values = scale.ticks(ticks || Math.floor(width / 100) || 1);
-  // @ts-ignore - This is a domain
-  const range: Domain = scale.range().map(r => r + halfStrokeWidth);
+  const range: Domain = scale.range().map(r => r + halfStrokeWidth) as Domain;
   const pathString = getPathString({
     height,
     placement,


### PR DESCRIPTION
When taking a known Domain (`[number, number]`) and running a `.map()`
function on it, TypeScript loses all knowledge of the fact that this
array is still a `[number, number]` (because it doesn't have to be).
Address this by explicitly casting these back to Domain afterwards so
that we don't need to disable TypeScript checking on the subsequent
line.