### PR TITLE
Add displayName to all exported components

### DIFF
--- a/src/components/AxisCollection/YAxis.js
+++ b/src/components/AxisCollection/YAxis.js
@@ -7,6 +7,7 @@ import AxisPlacement from '../AxisPlacement';
 import ScalerContext from '../../context/Scaler';
 import ZoomRect from '../ZoomRect';
 import Axes from '../../utils/Axes';
+import { withDisplayName } from '../../utils/displayName';
 
 const propTypes = {
   zoomable: PropTypes.bool,
@@ -252,10 +253,10 @@ const YAxis = ({
 YAxis.propTypes = propTypes;
 YAxis.defaultProps = defaultProps;
 
-export default props => (
+export default withDisplayName('YAxis', props => (
   <ScalerContext.Consumer>
     {({ subDomainsByItemId }) => (
       <YAxis {...props} subDomainsByItemId={subDomainsByItemId} />
     )}
   </ScalerContext.Consumer>
-);
+));

--- a/src/components/AxisCollection/index.js
+++ b/src/components/AxisCollection/index.js
@@ -9,6 +9,7 @@ import GriffPropTypes, {
 } from '../../utils/proptypes';
 import AxisDisplayMode from '../../utils/AxisDisplayMode';
 import AxisPlacement from '../AxisPlacement';
+import { withDisplayName } from '../../utils/displayName';
 
 const propTypes = {
   height: PropTypes.number.isRequired,
@@ -284,10 +285,10 @@ const AxisCollection = ({
 AxisCollection.propTypes = propTypes;
 AxisCollection.defaultProps = defaultProps;
 
-export default props => (
+export default withDisplayName('AxisCollection', props => (
   <ScalerContext.Consumer>
     {({ collections, series }) => (
       <AxisCollection {...props} collections={collections} series={series} />
     )}
   </ScalerContext.Consumer>
-);
+));

--- a/src/components/ContextChart/index.js
+++ b/src/components/ContextChart/index.js
@@ -13,6 +13,7 @@ import Axes from '../../utils/Axes';
 import { createYScale, createXScale } from '../../utils/scale-helpers';
 import { stripPlaceholderDomain } from '../Scaler';
 import { calculateDomainFromData } from '../DataProvider';
+import { withDisplayName } from '../../utils/displayName';
 
 const propTypes = {
   height: PropTypes.number,
@@ -162,7 +163,7 @@ const ContextChart = ({
 ContextChart.propTypes = propTypes;
 ContextChart.defaultProps = defaultProps;
 
-export default props => (
+export default withDisplayName('ContextChart', props => (
   <ScalerContext.Consumer>
     {({ domainsByItemId, subDomainsByItemId, updateDomains, series }) => (
       <SizeMe monitorWidth>
@@ -179,4 +180,4 @@ export default props => (
       </SizeMe>
     )}
   </ScalerContext.Consumer>
-);
+));

--- a/src/components/GridLines/index.tsx
+++ b/src/components/GridLines/index.tsx
@@ -5,6 +5,7 @@ import Axes from '../../utils/Axes';
 import { ItemId, Series } from '../../external';
 import { DomainsByItemId } from '../Scaler/index';
 import { SizeProps, ItemIdMap } from '../../internal';
+import { withDisplayName } from '../../utils/displayName';
 
 export interface GridX {
   pixels?: number;
@@ -205,16 +206,19 @@ const GridLines: React.FunctionComponent<Props & InternalProps & SizeProps> = ({
   return <g>{lines}</g>;
 };
 
-export default ({ width, height, ...props }: Props & SizeProps) => (
-  <ScalerContext.Consumer>
-    {({ series, subDomainsByItemId }: any) => (
-      <GridLines
-        {...props}
-        width={width}
-        height={height}
-        series={series}
-        subDomainsByItemId={subDomainsByItemId}
-      />
-    )}
-  </ScalerContext.Consumer>
+export default withDisplayName(
+  'GridLines',
+  ({ width, height, ...props }: Props & SizeProps) => (
+    <ScalerContext.Consumer>
+      {({ series, subDomainsByItemId }: any) => (
+        <GridLines
+          {...props}
+          width={width}
+          height={height}
+          series={series}
+          subDomainsByItemId={subDomainsByItemId}
+        />
+      )}
+    </ScalerContext.Consumer>
+  )
 );

--- a/src/components/InteractionLayer/index.js
+++ b/src/components/InteractionLayer/index.js
@@ -15,6 +15,7 @@ import Ruler from '../Ruler';
 import Area from '../Area';
 import ZoomRect from '../ZoomRect';
 import Axes from '../../utils/Axes';
+import { withDisplayName } from '../../utils/displayName';
 
 export const ZoomMode = {
   X: 0,
@@ -612,7 +613,7 @@ class InteractionLayer extends React.Component {
   }
 }
 
-export default props => (
+export default withDisplayName('InteractionLayer', props => (
   <ScalerContext.Consumer>
     {({ collections, series, subDomainsByItemId }) => (
       <InteractionLayer
@@ -623,4 +624,4 @@ export default props => (
       />
     )}
   </ScalerContext.Consumer>
-);
+));

--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -18,6 +18,7 @@ import AxisPlacement from '../AxisPlacement';
 import Layout from './Layout';
 import { multiFormat } from '../../utils/multiFormat';
 import Axes from '../../utils/Axes';
+import { withDisplayName } from '../../utils/displayName';
 
 const propTypes = {
   // Disable the ESLinter for this because they'll show up from react-sizeme.
@@ -362,10 +363,10 @@ LineChart.defaultProps = defaultProps;
 
 const SizedLineChart = sizeMe({ monitorHeight: true })(LineChart);
 
-export default props => (
+export default withDisplayName('LineChart', props => (
   <ScalerContext.Consumer>
     {({ collections, series }) => (
       <SizedLineChart {...props} collections={collections} series={series} />
     )}
   </ScalerContext.Consumer>
-);
+));

--- a/src/components/LineCollection/index.tsx
+++ b/src/components/LineCollection/index.tsx
@@ -10,6 +10,7 @@ import AxisDisplayMode from '../../utils/AxisDisplayMode';
 import Axes, { Dimension } from '../../utils/Axes';
 import { Series } from '../../external';
 import { DomainsByItemId } from '../Scaler';
+import { withDisplayName } from '../../utils/displayName';
 
 const { time, x } = Axes;
 
@@ -94,7 +95,7 @@ const LineCollection: React.FunctionComponent<
   );
 };
 
-export default (props: Props) => (
+export default withDisplayName('LineCollection', (props: Props) => (
   <ScalerContext.Consumer>
     {({ domainsByItemId, subDomainsByItemId, series }: InternalProps) => (
       <LineCollection
@@ -105,4 +106,4 @@ export default (props: Props) => (
       />
     )}
   </ScalerContext.Consumer>
-);
+));

--- a/src/components/PointCollection/index.tsx
+++ b/src/components/PointCollection/index.tsx
@@ -8,6 +8,7 @@ import { SizeProps } from '../../internal';
 import { Series, Datapoint } from '../../external';
 import { DomainsByItemId } from '../Scaler';
 import Points from '../Points';
+import { withDisplayName } from '../../utils/displayName';
 
 export interface Props {}
 
@@ -73,14 +74,17 @@ const PointCollection: React.FunctionComponent<
 PointCollection.propTypes = propTypes;
 PointCollection.defaultProps = defaultProps;
 
-export default (props: Props & SizeProps) => (
-  <ScalerContext.Consumer>
-    {({ subDomainsByItemId, series }: InternalProps) => (
-      <PointCollection
-        {...props}
-        series={series}
-        subDomainsByItemId={subDomainsByItemId}
-      />
-    )}
-  </ScalerContext.Consumer>
+export default withDisplayName(
+  'PointCollection',
+  (props: Props & SizeProps) => (
+    <ScalerContext.Consumer>
+      {({ subDomainsByItemId, series }: InternalProps) => (
+        <PointCollection
+          {...props}
+          series={series}
+          subDomainsByItemId={subDomainsByItemId}
+        />
+      )}
+    </ScalerContext.Consumer>
+  )
 );

--- a/src/components/Scaler/index.tsx
+++ b/src/components/Scaler/index.tsx
@@ -6,6 +6,7 @@ import GriffPropTypes, { seriesPropType } from '../../utils/proptypes';
 import Axes, { Domains, Dimension } from '../../utils/Axes';
 import { Domain, Series, Collection, ItemId } from '../../external';
 import { Item } from '../../internal';
+import { withDisplayName } from '../../utils/displayName';
 
 // TODO: Move this to DataProvider.
 type OnTimeSubDomainChanged = (timeSubDomain: Domain) => void;
@@ -399,10 +400,10 @@ class Scaler extends React.Component<Props, State> {
   }
 }
 
-export default (props: Props) => (
+export default withDisplayName('Scaler', (props: Props) => (
   <DataContext.Consumer>
     {(dataContext: DataContext) => (
       <Scaler {...props} dataContext={dataContext} />
     )}
   </DataContext.Consumer>
-);
+));

--- a/src/components/XAxis/index.tsx
+++ b/src/components/XAxis/index.tsx
@@ -9,6 +9,7 @@ import ZoomRect from '../ZoomRect';
 import { createXScale, ScalerFunctionFactory } from '../../utils/scale-helpers';
 import { Domain, Series } from '../../external';
 import { DomainsByItemId } from '../Scaler';
+import { withDisplayName } from '../../utils/displayName';
 
 export interface Props {
   axis: 'time' | 'x';
@@ -252,7 +253,7 @@ const XAxis: React.FunctionComponent<Props & ScalerProps & SizeProps> = ({
   );
 };
 
-export default (props: Props) => (
+export default withDisplayName('XAxis', (props: Props) => (
   <ScalerContext.Consumer>
     {({ domainsByItemId, subDomainsByItemId, series }: ScalerProps) => (
       <SizeMe monitorWidth>
@@ -268,4 +269,4 @@ export default (props: Props) => (
       </SizeMe>
     )}
   </ScalerContext.Consumer>
-);
+));

--- a/src/components/ZoomRect/index.js
+++ b/src/components/ZoomRect/index.js
@@ -5,6 +5,7 @@ import isEqual from 'lodash.isequal';
 import ScalerContext from '../../context/Scaler';
 import GriffPropTypes from '../../utils/proptypes';
 import Axes from '../../utils/Axes';
+import { withDisplayName } from '../../utils/displayName';
 
 const propTypes = {
   width: PropTypes.number.isRequired,
@@ -386,7 +387,7 @@ class ZoomRect extends React.Component {
 ZoomRect.propTypes = propTypes;
 ZoomRect.defaultProps = defaultProps;
 
-export default props => (
+export default withDisplayName('ZoomRect', props => (
   <ScalerContext.Consumer>
     {({ domainsByItemId, subDomainsByItemId, updateDomains }) => (
       <ZoomRect
@@ -397,4 +398,4 @@ export default props => (
       />
     )}
   </ScalerContext.Consumer>
-);
+));

--- a/src/utils/displayName.ts
+++ b/src/utils/displayName.ts
@@ -1,0 +1,8 @@
+export function withDisplayName<T extends {}>(
+  displayName: string,
+  Component: T
+): T {
+  // @ts-ignore - I don't know what T needs to be to allow this to work.
+  Component.displayName = displayName;
+  return Component;
+}

--- a/stories/ContextChart.stories.js
+++ b/stories/ContextChart.stories.js
@@ -21,43 +21,37 @@ storiesOf('components/ContextChart', module)
     </div>
   ))
   .add('default', () => (
-    <React.Fragment>
-      <div style={{ width: '100%' }}>
-        <DataProvider
-          defaultLoader={staticLoader}
-          timeDomain={staticXDomain}
-          series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
-        >
-          <ContextChart />
-        </DataProvider>
-      </div>
-    </React.Fragment>
+    <div style={{ width: '100%' }}>
+      <DataProvider
+        defaultLoader={staticLoader}
+        timeDomain={staticXDomain}
+        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+      >
+        <ContextChart />
+      </DataProvider>
+    </div>
   ))
   .add('height', () => (
-    <React.Fragment>
-      <div style={{ width: '100%' }}>
-        <DataProvider
-          defaultLoader={staticLoader}
-          timeDomain={staticXDomain}
-          series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
-        >
-          <ContextChart height={500} />
-        </DataProvider>
-      </div>
-    </React.Fragment>
+    <div style={{ width: '100%' }}>
+      <DataProvider
+        defaultLoader={staticLoader}
+        timeDomain={staticXDomain}
+        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+      >
+        <ContextChart height={500} />
+      </DataProvider>
+    </div>
   ))
   .add('annotations', () => (
-    <React.Fragment>
-      <div style={{ width: '100%' }}>
-        <DataProvider
-          defaultLoader={staticLoader}
-          timeDomain={staticXDomain}
-          series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
-        >
-          <ContextChart annotations={exampleAnnotations} />
-        </DataProvider>
-      </div>
-    </React.Fragment>
+    <div style={{ width: '100%' }}>
+      <DataProvider
+        defaultLoader={staticLoader}
+        timeDomain={staticXDomain}
+        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+      >
+        <ContextChart annotations={exampleAnnotations} />
+      </DataProvider>
+    </div>
   ))
   .add('zoomable', () => (
     <React.Fragment>
@@ -82,36 +76,32 @@ storiesOf('components/ContextChart', module)
     </React.Fragment>
   ))
   .add('xAxisFormatter', () => (
-    <React.Fragment>
-      <div style={{ width: '100%' }}>
-        <DataProvider
-          defaultLoader={staticLoader}
-          timeDomain={staticXDomain}
-          series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
-        >
-          <ContextChart
-            xAxisFormatter={date =>
-              `${(
-                100 *
-                ((date - staticXDomain[0]) /
-                  (staticXDomain[1] - staticXDomain[0]))
-              ).toFixed(0)}%`
-            }
-          />
-        </DataProvider>
-      </div>
-    </React.Fragment>
+    <div style={{ width: '100%' }}>
+      <DataProvider
+        defaultLoader={staticLoader}
+        timeDomain={staticXDomain}
+        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+      >
+        <ContextChart
+          xAxisFormatter={date =>
+            `${(
+              100 *
+              ((date - staticXDomain[0]) /
+                (staticXDomain[1] - staticXDomain[0]))
+            ).toFixed(0)}%`
+          }
+        />
+      </DataProvider>
+    </div>
   ))
   .add('xAxisPlacement', () => (
-    <React.Fragment>
-      <div style={{ width: '100%' }}>
-        <DataProvider
-          defaultLoader={staticLoader}
-          timeDomain={staticXDomain}
-          series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
-        >
-          <ContextChart xAxisPlacement={AxisPlacement.TOP} />
-        </DataProvider>
-      </div>
-    </React.Fragment>
+    <div style={{ width: '100%' }}>
+      <DataProvider
+        defaultLoader={staticLoader}
+        timeDomain={staticXDomain}
+        series={[{ id: 1, color: 'steelblue' }, { id: 2, color: 'maroon' }]}
+      >
+        <ContextChart xAxisPlacement={AxisPlacement.TOP} />
+      </DataProvider>
+    </div>
   ));


### PR DESCRIPTION
When components are exported as a function (such as when using the
Context API), they lose the displayName property. Add this back in so
that external tools (such as storybook's info addon) work better.