### PR TITLE
Clean up an `any` type declaration

### DIFF
--- a/src/components/GridLines/index.tsx
+++ b/src/components/GridLines/index.tsx
@@ -207,7 +207,13 @@ const GridLines: React.FunctionComponent<Props & InternalProps & SizeProps> = ({
 
 export default ({ width, height, ...props }: Props & SizeProps) => (
   <ScalerContext.Consumer>
-    {({ series, subDomainsByItemId }: any) => (
+    {({
+      series,
+      subDomainsByItemId,
+    }: {
+      series: Series[];
+      subDomainsByItemId: DomainsByItemId;
+    }) => (
       <GridLines
         {...props}
         width={width}


### PR DESCRIPTION
This was leftover as a TODO during a previous TypeScript migrationl;
clean it up to be more explicit about what it looks like.