### PR TITLE
Remove strokes from the Brush handles

### DIFF
--- a/src/components/Brush/index.tsx
+++ b/src/components/Brush/index.tsx
@@ -257,6 +257,7 @@ class Brush extends React.Component<Props, State> {
           height={height}
           fill="none"
           pointerEvents="all"
+          stroke="none"
           onMouseDown={this.onMouseDownHandleWest}
         />
         <path
@@ -274,6 +275,7 @@ class Brush extends React.Component<Props, State> {
           height={height}
           fill="none"
           pointerEvents="all"
+          stroke="none"
           onMouseDown={this.onMouseDownHandleEast}
         />
       </g>


### PR DESCRIPTION
I don't know when this changed to give them strokes by default, but it
makes the rendering weird. Set them back to none to remove the visual
clutter.