### PR TITLE
[OI-1832] Fix positioning of ruler points

### DIFF
--- a/src/components/InteractionLayer/index.js
+++ b/src/components/InteractionLayer/index.js
@@ -392,10 +392,8 @@ class InteractionLayer extends React.Component {
       if (!subDomainsByItemId[s.id]) {
         return;
       }
-      const {
-        [Axes.time]: timeSubDomain,
-        [Axes.y]: ySubDomain,
-      } = subDomainsByItemId[s.id];
+      const { [Axes.time]: timeSubDomain, [Axes.y]: ySubDomain } =
+        subDomainsByItemId[s.collectionId] || subDomainsByItemId[s.id];
       const xScale = createXScale(timeSubDomain, width);
       const rawTimestamp = xScale.invert(xpos);
       const { data, xAccessor, yAccessor } = s;

--- a/stories/Collection.stories.js
+++ b/stories/Collection.stories.js
@@ -66,6 +66,10 @@ export const flatStructure = () => (
   </DataProvider>
 );
 
+flatStructure.story = {
+  name: 'Flat structure',
+};
+
 export const Ruler = () => (
   <DataProvider defaultLoader={staticLoader} timeDomain={staticXDomain}>
     <Collection id="collection" />
@@ -89,10 +93,6 @@ export const Ruler = () => (
     />
   </DataProvider>
 );
-
-flatStructure.story = {
-  name: 'Flat structure',
-};
 
 export const changeProps = () => (
   <ToggleRenderer

--- a/stories/Collection.stories.js
+++ b/stories/Collection.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import {
   Collection,
   DataProvider,
@@ -62,6 +63,30 @@ export const flatStructure = () => (
     <Series id="1" color="steelblue" collectionId="collection" />
     <Series id="2" color="maroon" collectionId="collection" />
     <LineChart height={CHART_HEIGHT} />
+  </DataProvider>
+);
+
+export const Ruler = () => (
+  <DataProvider defaultLoader={staticLoader} timeDomain={staticXDomain}>
+    <Collection id="collection" />
+    <Series
+      id="1"
+      color="steelblue"
+      collectionId="collection"
+      name="Series 1"
+    />
+    <Series id="2" color="maroon" collectionId="collection" name="Series 2" />
+    <LineChart
+      height={CHART_HEIGHT}
+      crosshair={false}
+      ruler={{
+        visible: true,
+        yLabel: point =>
+          `${point.name}: ${Number.parseFloat(point.value).toFixed(3)}`,
+        timeLabel: point =>
+          moment(point.timestamp).format('DD-MM-YYYY HH:mm:ss'),
+      }}
+    />
   </DataProvider>
 );
 


### PR DESCRIPTION
When calculating ruler points the subdomain of the collection should be used (if available) instead of the subdomain of the individual series. Also added a story to test this functionality.

Once this is merged, bumping this package in insight will fix [OI-1832]

[OI-1832]: https://cognitedata.atlassian.net/browse/OI-1832