### PR TITLE
fix: Make annotation and area keys more specific

### DIFF
--- a/src/components/InteractionLayer/index.js
+++ b/src/components/InteractionLayer/index.js
@@ -536,7 +536,12 @@ class InteractionLayer extends React.Component {
     const timeSubDomain = Axes.time(subDomainsByItemId[series[0].id]);
     const xScale = createXScale(timeSubDomain, width);
     const annotations = propsAnnotations.map(a => (
-      <Annotation key={a.id} {...a} height={height} xScale={xScale} />
+      <Annotation
+        key={`annotation-${a.id}`}
+        {...a}
+        height={height}
+        xScale={xScale}
+      />
     ));
     const areas = propsAreas.map(a => {
       const scaledArea = {
@@ -566,7 +571,9 @@ class InteractionLayer extends React.Component {
         }
       }
       const color = scaledArea.color || (s ? s.color : null);
-      return <Area key={scaledArea.id} color={color} {...scaledArea} />;
+      return (
+        <Area key={`area-${scaledArea.id}`} color={color} {...scaledArea} />
+      );
     });
     const areaBeingDefined = area ? (
       <Area key="user" {...area} color="#999" />


### PR DESCRIPTION
This way keys won't clash if annotations and areas have the same ids.