### PR TITLE
Handle when there is no data in the loader

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -378,7 +378,8 @@ export default class DataProvider extends Component {
           // We either couldn't have any data before ...
           reason === 'MOUNTED' ||
           // ... or we didn't have data before, but do now!
-          (freshSeries.data.length === 0 && loaderResult.data.length > 0)
+          ((freshSeries.data || []).length === 0 &&
+            (loaderResult.data || []).length > 0)
         ) {
           const collection = series.collectionId
             ? collectionsById[series.collectionId] || {}


### PR DESCRIPTION
If there isn't data in the DataProvider, and there wasn't any returned
by the loader, then we shouldn't crash. Instead, handle this gracefully
by assuming no data.