### PR TITLE
Add ability to recalcuate the data for yaxis if time subdomain changed

### DIFF
--- a/src/components/DataProvider/index.js
+++ b/src/components/DataProvider/index.js
@@ -333,6 +333,7 @@ export default class DataProvider extends Component {
       y1Accessor,
       yAccessor,
       onFetchDataError,
+      recalcDataTimeSubDomainChanged,
     } = this.props;
     const { timeDomain, timeSubDomain, seriesById } = this.state;
     const seriesObject = seriesById[id];
@@ -377,6 +378,8 @@ export default class DataProvider extends Component {
         if (
           // We either couldn't have any data before ...
           reason === 'MOUNTED' ||
+          // Or the subdomain changed and we need to recalc the yDomain
+          (reason === 'UPDATE_SUBDOMAIN' && recalcDataTimeSubDomainChanged) ||
           // ... or we didn't have data before, but do now!
           ((freshSeries.data || []).length === 0 &&
             (loaderResult.data || []).length > 0)
@@ -809,6 +812,8 @@ DataProvider.propTypes = {
       id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
     })
   ),
+  // Determines whether to recalc the data if the time subdomain changed
+  recalcDataTimeSubDomainChanged: PropTypes.bool,
 };
 
 DataProvider.defaultProps = {
@@ -847,4 +852,5 @@ DataProvider.defaultProps = {
   },
   series: [],
   collections: [],
+  recalcDataTimeSubDomainChanged: false,
 };


### PR DESCRIPTION
When we are using griff-react (with cogniteloader from griff-loader) in AIR, we are running into an issue where we use the default yDomain provided by griff-react. When we originally load our data, we load it from the span of one year, so many datapoints are aggregated and some of the extreme data points are averaged out. 

However, when we zoom in and adjust the timeSubdomain, we would like to see these extreme data points. But as we change the timeSubdomain, the yDomain doesn't change to reflect the new data (where the extreme datapoints would no longer necessarily be averaged out). The only way we can see these time points is to selectively zoom in/out on the yDomain - which isn't a great user experience.

This can be seen here if you have access to akerbp-test:

https://staging.air.cogniteapp.com/akerbp-test/dashboard/CVX6BTLRndnhkhpDTsIM/system/FGYWEw1VbX5dT9ZSmfca/timeseries/3462954466371299/alert/6648319396225031

With this change - we could provide a prop to DataProvider to tell it to recalculate the data when the timeSubDomain changes.

This feels a bit hacky and like I might be overlooking a better way to do this - so please let me know if there's a better approach you can think of! 